### PR TITLE
primary factories set in globals

### DIFF
--- a/contracts/MapleGlobals.sol
+++ b/contracts/MapleGlobals.sol
@@ -38,6 +38,10 @@ contract MapleGlobals {
     mapping(bytes32 => address) public interestStructureCalculators;
     bytes32[] public validInterestStructures;
 
+    // @return primary factory addresses
+    address public loanVaultFactory;
+    address public liquidityPoolFactory;
+
     modifier isGovernor() {
         require(msg.sender == governor, "MapleGlobals::ERR_MSG_SENDER_NOT_GOVERNOR");
         _;
@@ -58,6 +62,14 @@ contract MapleGlobals {
         stakeAmountRequired = 25000;
         unstakeDelay = 90 days;
         drawdownGracePeriod = 1 days;
+    }
+
+    function setLiquidityPoolFactory(address _factory) external isGovernor {
+        liquidityPoolFactory = _factory;
+    }
+
+    function setLoanVaultFactory(address _factory) external isGovernor {
+        loanVaultFactory = _factory;
     }
 
     /**
@@ -87,11 +99,11 @@ contract MapleGlobals {
      */
     function addValidInterestStructure(bytes32 _type, address _calculator) external isGovernor {
         require(
-            _calculator != address(0), 
+            _calculator != address(0),
             "MapleGloblas::addValidInterestStructure:ERR_NULL_ADDRESS_SUPPLIED_FOR_CALCULATOR"
         );
         require(
-            interestStructureCalculators[_type] == address(0), 
+            interestStructureCalculators[_type] == address(0),
             "MapleGloblas::addValidInterestStructure:ERR_ALREADY_ADDED"
         );
         interestStructureCalculators[_type] = _calculator;

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -48,25 +48,28 @@ async function main() {
   await mapleGlobals.addBorrowToken(WBTCAddress);
 
   // TODO: Create repayment calculators, use bunk ones temporarily.
-  const BUNK_ADDRESS_AMORTIZATION = "0x0000000000000000000000000000000000000001";
+  const BUNK_ADDRESS_AMORTIZATION =
+    "0x0000000000000000000000000000000000000001";
   const BUNK_ADDRESS_BULLET = "0x0000000000000000000000000000000000000002";
   const updateGlobalsRepaymentCalcAmortization = await mapleGlobals.setInterestStructureCalculator(
-    ethers.utils.formatBytes32String('AMORTIZATION'),
+    ethers.utils.formatBytes32String("AMORTIZATION"),
     BUNK_ADDRESS_AMORTIZATION
   );
   const updateGlobalsRepaymentCalcBullet = await mapleGlobals.setInterestStructureCalculator(
-    ethers.utils.formatBytes32String('BULLET'),
+    ethers.utils.formatBytes32String("BULLET"),
     BUNK_ADDRESS_BULLET
   );
 
-  const CollateralLockerFactory = await deploy("LoanVaultCollateralLockerFactory",);
+  const CollateralLockerFactory = await deploy(
+    "LoanVaultCollateralLockerFactory"
+  );
 
   const FundingLockerFactory = await deploy("LoanVaultFundingLockerFactory");
 
   const LVFactory = await deploy("LoanVaultFactory", [
     mapleGlobals.address,
     FundingLockerFactory.address,
-    CollateralLockerFactory.address
+    CollateralLockerFactory.address,
   ]);
 
   const updateFundingLockerFactory = await LVFactory.setFundingLockerFactory(
@@ -77,6 +80,9 @@ async function main() {
     CollateralLockerFactory.address
   );
 
+  await mapleGlobals.setLiquidityPoolFactory(LPFactory.address);
+
+  await mapleGlobals.setLoanVaultFactory(LVFactory.address);
 }
 
 main()

--- a/test/globals-init.js
+++ b/test/globals-init.js
@@ -3,6 +3,9 @@ const { expect, assert } = require("chai");
 const globalAddress = require("../../contracts/localhost/addresses/MapleGlobals.address");
 const globalABI = require("../../contracts/localhost/abis/MapleGlobals.abi");
 const mapleTokenAddress = require("../../contracts/localhost/addresses/MapleToken.address");
+const LPFactoryAddress = require("../../contracts/localhost/addresses/LPFactory.address.js");
+const LVFactoryAddress = require("../../contracts/localhost/addresses/LoanVaultFactory.address.js");
+
 
 describe("MapleGlobals.sol Initialization", function () {
   let mapleGlobals;
@@ -33,21 +36,10 @@ describe("MapleGlobals.sol Initialization", function () {
     expect(unstakeDelay).to.equal(7776000);
   });
 
-  it("paymentInterval mapping is initialized properly", async function () {
-    // Valid cases.
-    const paymentIntervalMonthlyValid = await mapleGlobals.validPaymentIntervalSeconds(2592000);
-    const paymentIntervalQuarterlyValid = await mapleGlobals.validPaymentIntervalSeconds(7776000);
-    const paymentIntervalSemiAnnuallyValid = await mapleGlobals.validPaymentIntervalSeconds(15552000);
-    const paymentIntervalAnnuallyValid = await mapleGlobals.validPaymentIntervalSeconds(31104000);
-    expect(paymentIntervalMonthlyValid);
-    expect(paymentIntervalQuarterlyValid);
-    expect(paymentIntervalSemiAnnuallyValid);
-    expect(paymentIntervalAnnuallyValid);
-    // Invalid cases.
-    const paymentIntervalZeroInvalid = await mapleGlobals.validPaymentIntervalSeconds(0);
-    const paymentIntervalMonthlyInvalid = await mapleGlobals.validPaymentIntervalSeconds(2592001);
-    expect(!paymentIntervalZeroInvalid);
-    expect(!paymentIntervalMonthlyInvalid);
-  });
-
+   it("factory addresses set properly in globals", async function () {
+	const LPFaddress = await mapleGlobals.liquidityPoolFactory();
+	const LVFaddress = await mapleGlobals.loanVaultFactory();
+	expect(LPFaddress).to.equal(LPFactoryAddress);
+	expect(LVFaddress).to.equal(LVFactoryAddress);
+   })
 });

--- a/test/globals-set.js
+++ b/test/globals-set.js
@@ -85,10 +85,6 @@ describe("MapleGlobals.sol Interactions", function () {
       "MapleGlobals::ERR_MSG_SENDER_NOT_GOVERNOR"
     );
 
-    await expect(mapleGlobals.setPaymentIntervalValidity(86400, true)).to.be.revertedWith(
-      "MapleGlobals::ERR_MSG_SENDER_NOT_GOVERNOR"
-    );
-
     const BUNK_ADDRESS_AMORTIZATION = "0x0000000000000000000000000000000000000003";
 
     await expect(mapleGlobals.setInterestStructureCalculator(


### PR DESCRIPTION
just added setters and public vars for LP and LV factory in globals, and set them at deploy, and tested that they were set correctly. removed deprecated tests on removed features in globals. 

a few superficial changes here are from prettier 