### PR TITLE
Specifying host and port in yarn chain command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "maple-core",
   "version": "1.0.0",
   "scripts": {
-    "chain": "hardhat node",
+    "chain": "hardhat node --hostname 0.0.0.0 --port 8545",
     "test": "hardhat test",
     "test:globals": "yarn deploy && hardhat test test/globals-init.js && hardhat test test/globals-set.js && yarn deploy",
     "test:token": "yarn deploy && hardhat test test/mapletoken-basic.js",


### PR DESCRIPTION
Hardhat node runs on 127.0.0.1 by default which causes issues when trying to connect to the node from withing docker container on Linux. Setting host to 0.0.0.0 fixes this issue. This change should not affect Mac and Windows.