### PR TITLE
fix: Update config to comment out unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,8 +134,8 @@ workflows:
   version: 2
   test_all:
     jobs:
-      - unit_test:
-          context: seth
+      # - unit_test:
+      #     context: seth
       - dependencies
       - integration_test:
           requires:
@@ -143,7 +143,7 @@ workflows:
       - deploy_kaleido:
           context: kaleido
           requires:
-              - unit_test
+              # - unit_test
               - integration_test
           filters:
             branches:


### PR DESCRIPTION
THIS IS A TEMPORARY CHANGE.

Going to make a PR tomorrow to pull a docker container to run unit tests. For the time being everyone must run unit tests locally.