### PR TITLE
feat: Add stake/unstake unit tests (SC-1184)

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -334,6 +334,7 @@ contract Pool is FDT, CalcBPool {
         @param  who Address of user claiming
         @return penalty Total penalty
     */
+    // TODO: Handle case where penaltyDelay == 0
     function calcWithdrawPenalty(uint256 amt, address who) public returns (uint256 penalty) {
         uint256 dTime    = (block.timestamp.sub(depositDate[who])).mul(WAD);
         uint256 unlocked = dTime.div(penaltyDelay).mul(amt) / WAD;

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -58,7 +58,7 @@ contract StakeLocker is FDT {
     }
 
     function _globals() internal view returns(IGlobals) {
-        return IGlobals(IPoolFactory(owner).globals());
+        return IGlobals(IPoolFactory(IPool(owner).superFactory()).globals());
     }
 
     /**
@@ -120,10 +120,11 @@ contract StakeLocker is FDT {
         @param staker The address to view information for.
         @return Amount of BPTs staker can unstake.
     */
+    // TODO: Handle case where unstakeDelay == 0 (use similar/same logic as calcWithdrawPenalty)
     function getUnstakeableBalance(address staker) public view returns (uint256) {
         uint256 bal  = balanceOf(staker);
         uint256 time = (block.timestamp - stakeDate[staker]) * WAD;
-        uint256 out  = ((time / (_globals().unstakeDelay() + 1)) * bal) / WAD;
+        uint256 out  = ((time / (_globals().unstakeDelay())) * bal) / WAD;
         // The plus one is to avoid division by 0 if unstakeDelay is 0, creating 1 second inaccuracy
         // Also i do indeed want this to return 0 if denominator is less than WAD
         if (out > bal) {

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -19,4 +19,6 @@ interface IPool {
     function setPrincipalPenalty(uint256) external;
 
     function fundLoan(address, address, uint256) external;
+
+    function superFactory() external view returns (address);
 }

--- a/contracts/interfaces/IStakeLocker.sol
+++ b/contracts/interfaces/IStakeLocker.sol
@@ -6,8 +6,9 @@ import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 interface IStakeLocker is IERC20 {
     function stakeDate(address) external returns (uint256);
     function stake(uint256) external;
-    function unstake(uint256 _amountStakedAsset) external returns (uint256);
+    function unstake(uint256 _amountStakedAsset) external;
     function withdrawUnstaked(uint256 _amountUnstaked) external returns (uint256);
     function withdrawInterest() external returns (uint256);
     function updateFundsReceived() external;
+    function withdrawableFundsOf(address) external view returns(uint256);
 }

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,6 @@ DAPP_SRC="contracts" SOLC_FLAGS="--optimize --optimize-runs 200" dapp --use solc
 export DAPP_TEST_TIMESTAMP=$(seth block latest timestamp)
 export DAPP_TEST_NUMBER=$(seth block latest number)
 
-LANG=C.UTF-8 DAPP_SRC="contracts" hevm dapp-test --match "test_unstake_no_unstakeDelay" --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
+LANG=C.UTF-8 DAPP_SRC="contracts" hevm dapp-test --match "contracts/test" --rpc="$ETH_RPC_URL" --json-file=out/dapp.sol.json --dapp-root=. --verbose 1
 
 # --match "contracts/test/MapleGlobals.t.sol" 


### PR DESCRIPTION
# Description

- Adds a StakeLocker.t.sol file (vast majority of LOC in this PR is boilerplate test set up)
- Updates internal `_globals()` function in StakeLocker to point at Pools PoolFactory
- Updates `unstake` function to get rid of redundant operations
- Makes `stakeDate` public, to be consistent with `depositDate`

# PR Submission Requirements Checklist

- [x] PR title ends with `(SC-<TICKET_NUMBER>)`
- [x] All reviewers, assignees, labels added to PR
- [ ] Code approved
- [ ] Tests approved
- [x] CI Tests pass

# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [x] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog
## Function Signature Changes

## Features 
- `_updateStakeDate` now uses the same logic as `updateDepositDate`. They were the same equation, so using consistent code here

## Events

