### PR TITLE
feat: `nextPaymentDue` on `drawdown()` (SC-1516)

### DIFF
--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -163,7 +163,6 @@ contract Loan is FDT, Pausable {
         repaymentCalc          = calcs[0];
         lateFeeCalc            = calcs[1];
         premiumCalc            = calcs[2];
-        nextPaymentDue         = block.timestamp.add(paymentIntervalSeconds);
         superFactory           = msg.sender;
 
         // Deploy lockers
@@ -218,9 +217,10 @@ contract Loan is FDT, Pausable {
         require(amt >= requestAmount,               "Loan:AMT_LT_MIN_RAISE");
         require(amt <= _getFundingLockerBalance(),  "Loan:AMT_GT_FUNDED_AMT");
 
-        // Update the principal owed and drawdown amount for this loan.
+        // Update accounting variables for Loan
         principalOwed  = amt;
         drawdownAmount = amt;
+        nextPaymentDue = block.timestamp.add(paymentIntervalSeconds);
 
         loanState = State.Active;
 

--- a/contracts/test/Loan.t.sol
+++ b/contracts/test/Loan.t.sol
@@ -120,7 +120,6 @@ contract LoanTest is TestUtil {
         assertEq(loan.repaymentCalc(),             address(repaymentCalc));
         assertEq(loan.lateFeeCalc(),               address(lateFeeCalc));
         assertEq(loan.premiumCalc(),               address(premiumCalc));
-        assertEq(loan.nextPaymentDue(),            block.timestamp + loan.paymentIntervalSeconds());
     }
 
     function test_fundLoan() public {
@@ -202,7 +201,8 @@ contract LoanTest is TestUtil {
         assertEq(loan.principalOwed(),                           1000 * USD);  // Principal owed
         assertEq(uint256(loan.loanState()),                               1);  // Loan state: Active
 
-        
+        assertEq(loan.nextPaymentDue(), block.timestamp + loan.paymentIntervalSeconds());  // Next payment due timestamp calculated from time of drawdown
+
         // Fee related variables post-check.
         assertEq(loan.feePaid(),                          5 * USD);  // Drawdown amount
         assertEq(loan.excessReturned(),                4000 * USD);  // Principal owed

--- a/contracts/test/LoanFactory.t.sol
+++ b/contracts/test/LoanFactory.t.sol
@@ -203,7 +203,6 @@ contract LoanFactoryTest is TestUtil {
         assertEq(loan.repaymentCalc(),             calcs[0], "Incorrect repayment calculator");
         assertEq(loan.lateFeeCalc(),               calcs[1], "Incorrect late fee calculator");
         assertEq(loan.premiumCalc(),               calcs[2], "Incorrect premium calculator");
-        assertEq(loan.nextPaymentDue(),            (loan.createdAt()).add(loan.paymentIntervalSeconds()), "Incorrect next payment due timestamp");
         assertEq(loan.superFactory(),              address(lFactory), "Incorrect super factory address");
     }
 }


### PR DESCRIPTION
# Description

This PR moves the initial declaration of nextPaymentDue from the Loan constructor to the `drawdown()` function, meaning that the nextPaymentDue is calculated from when the loan is initially drawn down on.

