### PR TITLE
fix: Add `updateFundsReceived` to `drawdown` (SC-1571)

### DIFF
--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -250,6 +250,9 @@ contract Loan is FDT, Pausable {
         // Drain remaining funds from FundingLocker (amount equal to excessReturned)
         _fundingLocker.drain();
 
+        // Call updateFundsReceived() update FDT accounting with funds recieved from fees and excess returned
+        updateFundsReceived();
+
         _emitBalanceUpdateEventForCollateralLocker();
         _emitBalanceUpdateEventForFundingLocker();
         _emitBalanceUpdateEventForLoan();

--- a/contracts/test/Loan.t.sol
+++ b/contracts/test/Loan.t.sol
@@ -208,6 +208,16 @@ contract LoanTest is TestUtil {
         assertEq(loan.excessReturned(),                4000 * USD);  // Principal owed
         assertEq(IERC20(USDC).balanceOf(address(trs)),    5 * USD);  // Treasury reqAsset balance
 
+        // Test FDT accounting
+        assertEq(IERC20(USDC).balanceOf(address(bob)), 0);
+
+        bob.withdrawFunds(address(loan));
+
+        withinDiff(IERC20(USDC).balanceOf(address(bob)),              4005 * USD, 1);
+        withinDiff(IERC20(loan.loanAsset()).balanceOf(address(loan)),          0, 1);
+
+        // Can't drawdown() loan after it has already been called.
+        assertTrue(!ali.try_drawdown(address(loan), 1000 * USD));
     }
 
     function test_makePayment() public {


### PR DESCRIPTION
# Description

Adds `updateFundsRecieved` to `drawdown` function, adds test coverage for individual LoanFDT holders claiming funds post-drawdown.

