### PR TITLE
Allow test match argument and skipping mainnet check

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -10,4 +10,6 @@ export DAPP_SRC="contracts"
 export SOLC_FLAGS="--optimize --optimize-runs 200"
 export DAPP_LINK_TEST_LIBRARIES=1
 
-LANG=C.UTF-8 dapp test --match "contracts/test" --rpc-url "$ETH_RPC_URL" --verbose --cache "cache/dapp-cache" --fuzz-runs 100
+if [ ${1} ]; then match=${1}; else match="contracts/test"; fi
+
+LANG=C.UTF-8 dapp test --match "$match" --rpc-url "$ETH_RPC_URL" --verbose --cache "cache/dapp-cache" --fuzz-runs 100


### PR DESCRIPTION
# Description

- Allow a test match argument to be passed in to `test.sh`, e.g.: `./test.sh LoanTest.test_fundLoan`
- Allow skipping the mainnet check everytime `test.sh` runs by setting the env `SKIP_MAINNET_CHECK=1`