### PR TITLE
feat: Add open StakeLocker to public functionality (SC-1624)

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -51,7 +51,7 @@ contract Pool is PoolFDT {
     uint256 public liquidityCap;      // Amount of liquidity tokens accepted by the Pool
     uint256 public lockupPeriod;      // Unix timestamp during which withdrawal is not allowed
 
-    bool public openToPublic;         // Switch to make pool accessible for the public.
+    bool public openToPublic;  // Boolean opening Pool to public for LP deposits
 
     enum State { Initialized, Finalized, Deactivated }
     State public poolState;  // The current state of this pool
@@ -63,6 +63,7 @@ contract Pool is PoolFDT {
     mapping(address => uint256)                     public depositCooldown;            // Timestamp of when LP calls `intendToWithdraw()`
 
     // TODO: Check if offchain team needs a `PoolOpened` event
+    // TODO: Check if offchain team needs a `StakeLockerOpened` event
     event       LoanFunded(address indexed loan, address debtLocker, uint256 amountFunded);
     event            Claim(address indexed loan, uint256 interest, uint256 principal, uint256 fee);
     event   BalanceUpdated(address indexed who,  address token, uint256 balance);
@@ -154,6 +155,14 @@ contract Pool is PoolFDT {
     function openPoolToPublic() external {
         _isValidDelegateAndProtocolNotPaused();
         openToPublic = true;
+    }
+
+    /**
+        @dev Open StakeLocker to public. Once it is set to `true` it cannot be set back to `false`.
+    */
+    function openStakeLockerToPublic() external {
+        _isValidDelegateAndProtocolNotPaused();
+        IStakeLocker(stakeLocker).openStakeLockerToPublic();
     }
 
     /**

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -28,6 +28,8 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     mapping(address => uint256) public stakeCooldown;  // Timestamp of when staker called cooldown()
     mapping(address => bool)    public allowed;        // Map address to allowed status
 
+    bool public openToPublic;  // Boolean opening StakeLocker to public for staking BPTs
+
     event   BalanceUpdated(address stakeLocker, address token, uint256 balance);
     event AllowListUpdated(address staker, bool status);
     event StakeDateUpdated(address staker, uint256 stakeDate);
@@ -91,6 +93,13 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     function setAllowlist(address user, bool status) isPool public {
         allowed[user] = status;
         emit AllowListUpdated(user, status);
+    }
+
+    /**
+        @dev Open StakerLocker to public. Once it is set to `true` it cannot be set back to `false`.
+    */
+    function openStakeLockerToPublic() isPool external {
+        openToPublic = true;
     }
 
     /**
@@ -272,7 +281,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     */
     function _isAllowed(address user) internal view {
         require(
-            allowed[user] || user == IPool(owner).poolDelegate(), 
+            allowed[user] || openToPublic || user == IPool(owner).poolDelegate(), 
             "StakeLocker:MSG_SENDER_NOT_ALLOWED"
         );
     }

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -50,5 +50,7 @@ interface IPool {
 
     function openToPublic() external view returns(bool);
 
+    function openStakeLockerToPublic() external view returns(bool);
+
     function intendToWithdraw() external;
 }

--- a/contracts/interfaces/IStakeLocker.sol
+++ b/contracts/interfaces/IStakeLocker.sol
@@ -22,6 +22,12 @@ interface IStakeLocker is IERC20 {
 
     function setAllowlist(address, bool) external;
 
+    function openStakeLockerToPublic() external;
+
+    function openToPublic() external view returns (bool);
+
+    function allowed(address) external view returns (bool);
+
     function getUnstakeableBalance(address) external view returns (uint256);
 
     function updateLosses(uint256) external;

--- a/contracts/test/user/PoolDelegate.sol
+++ b/contracts/test/user/PoolDelegate.sol
@@ -89,6 +89,10 @@ contract PoolDelegate {
         IPool(pool).openPoolToPublic();
     }
 
+    function openStakeLockerToPublic(address pool) external {
+        IPool(pool).openStakeLockerToPublic();
+    }
+
     function setAllowList(address pool, address user, bool status) external {
         IPool(pool).setAllowList(user, status);
     }
@@ -163,6 +167,11 @@ contract PoolDelegate {
 
     function try_openPoolToPublic(address pool) external returns(bool ok) {
         string memory sig = "openPoolToPublic()";
+        (ok,) = address(pool).call(abi.encodeWithSignature(sig));
+    }
+
+    function try_openStakeLockerToPublic(address pool) external returns(bool ok) {
+        string memory sig = "openStakeLockerToPublic()";
         (ok,) = address(pool).call(abi.encodeWithSignature(sig));
     }
 


### PR DESCRIPTION
# Description

Adds a function similar to the Pool to flip a boolean value to true to open the StakeLocker to the public so anyone can stake BPTs

