### PR TITLE
feat: Remove superfluous liquidityCap sanity check

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -104,7 +104,7 @@ contract Pool is PoolFDT {
     ) PoolFDT(name, symbol) public {
 
         // Conduct sanity checks on Pool params
-        PoolLib.poolSanityChecks(_globals(msg.sender), _liquidityAsset, _stakeAsset, _liquidityCap, _stakingFee, _delegateFee);
+        PoolLib.poolSanityChecks(_globals(msg.sender), _liquidityAsset, _stakeAsset, _stakingFee, _delegateFee);
 
         // Assign variables relating to liquidityAsset
         liquidityAsset         = IERC20(_liquidityAsset);

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -35,7 +35,6 @@ library PoolLib {
         @param globals        Address of MapleGlobals
         @param liquidityAsset Asset used by Pool for liquidity to fund loans
         @param stakeAsset     Asset escrowed in StakeLocker
-        @param liquidityCap   Max amount of liquidityAsset accepted by the Pool
         @param stakingFee     Fee that `stakers` earn on interest, in basis points
         @param delegateFee    Fee that `_poolDelegate` earns on interest, in basis points
     */
@@ -43,12 +42,10 @@ library PoolLib {
         IGlobals globals, 
         address liquidityAsset, 
         address stakeAsset, 
-        uint256 liquidityCap, 
         uint256 stakingFee, 
         uint256 delegateFee
     ) external {
         require(globals.isValidLoanAsset(liquidityAsset),  "Pool:INVALID_LIQ_ASSET");
-        require(liquidityCap != uint256(0),                "Pool:INVALID_CAP");
         require(stakingFee.add(delegateFee) <= 10_000,     "Pool:INVALID_FEES");
         require(
             IBPool(stakeAsset).isBound(globals.mpl())  && 


### PR DESCRIPTION
# Description
There's no reason to prevent a `Pool` from being created with a `liquidityCap` value of 0, since they could just set it to 0 via `setLiquidityCap(0)` after instantiation.

Removing this sanity check allows a Pool Delegate to create a Pool that's initially in a paused state (without having to call `setLiquidityCap(0)` first before finalizing) which may be useful.