### PR TITLE
feat: Remove deactivate() confirmation

### DIFF
--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -260,13 +260,11 @@ contract Pool is PoolFDT {
 
     /**
         @dev Pool Delegate triggers deactivation, permanently shutting down the pool. Must have less than 100 USD worth of liquidityAsset principalOut.
-        @param confirmation Pool delegate must supply the number 86 for this function to deactivate, a simple confirmation.
     */
-    // TODO: Ask auditors about standard for confirmations
-    function deactivate(uint confirmation) external {
+    function deactivate() external {
         _isValidDelegateAndProtocolNotPaused();
         _isValidState(State.Finalized);
-        PoolLib.validateDeactivation(_globals(superFactory), confirmation, principalOut, address(liquidityAsset));
+        PoolLib.validateDeactivation(_globals(superFactory), principalOut, address(liquidityAsset));
         poolState = State.Deactivated;
         emit PoolStateChanged(poolState);
     }

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -12,7 +12,7 @@ interface IPool {
 
     function poolState() external view returns(uint256);
 
-    function deactivate(uint256) external;
+    function deactivate() external;
 
     function finalize() external;
 

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -194,12 +194,10 @@ library PoolLib {
     /**
         @dev Check whether the deactivation is allowed or not.
         @param  globals        Globals contract interface
-        @param  confirmation   Pool delegate must supply the number 86 for this function to deactivate, a simple confirmation.
         @param  principalOut   Amount of funds that is already funded to loans.
         @param  liquidityAsset Liquidity Asset of the pool 
      */
-    function validateDeactivation(IGlobals globals, uint256 confirmation, uint256 principalOut, address liquidityAsset) public view {
-        require(confirmation == 86, "Pool:INVALID_CONFIRMATION");
+    function validateDeactivation(IGlobals globals, uint256 principalOut, address liquidityAsset) public view {
         require(principalOut <= convertFromUsd(globals, liquidityAsset, 100), "Pool:PRINCIPAL_OUTSTANDING");
     }
 

--- a/contracts/test/Pool.t.sol
+++ b/contracts/test/Pool.t.sol
@@ -1943,11 +1943,11 @@ contract PoolTest is TestUtil {
 
         // Pause protocol and attempt deactivate()
         assertTrue( mic.try_setProtocolPause(address(globals), true));
-        assertTrue(!sid.try_deactivate(address(pool1), 86));
+        assertTrue(!sid.try_deactivate(address(pool1)));
 
         // Unpause protocol and deactivate()
         assertTrue(mic.try_setProtocolPause(address(globals), false));
-        assertTrue(sid.try_deactivate(address(pool1), 86));
+        assertTrue(sid.try_deactivate(address(pool1)));
 
         // Post-state checks.
         assertEq(int(pool1.poolState()), 2);
@@ -1963,7 +1963,7 @@ contract PoolTest is TestUtil {
         assertTrue(!sid.try_fundLoan(address(pool1), address(loan), address(dlFactory1), 1));
 
         // deactivate()
-        assertTrue(!sid.try_deactivate(address(pool1), 86));
+        assertTrue(!sid.try_deactivate(address(pool1)));
 
     }
 
@@ -2017,7 +2017,7 @@ contract PoolTest is TestUtil {
 
         // Pre-state checks.
         assertTrue(pool1.principalOut() >= 100 * 10 ** liquidityAssetDecimals);
-        assertTrue(!sid.try_deactivate(address(pool1), 86));
+        assertTrue(!sid.try_deactivate(address(pool1)));
     }
 
     function test_view_balance() public {

--- a/contracts/test/user/PoolDelegate.sol
+++ b/contracts/test/user/PoolDelegate.sol
@@ -61,8 +61,8 @@ contract PoolDelegate {
         return IPool(pool).claim(loan, dlFactory);  
     }
 
-    function deactivate(address pool, uint confirmation) external {
-        IPool(pool).deactivate(confirmation);
+    function deactivate(address pool) external {
+        IPool(pool).deactivate();
     }
 
     function setPrincipalPenalty(address pool, uint256 penalty) external {
@@ -145,9 +145,9 @@ contract PoolDelegate {
         (ok,) = address(pool).call(abi.encodeWithSignature(sig, delay));
     }
 
-    function try_deactivate(address pool, uint confirmation) external returns(bool ok) {
-        string memory sig = "deactivate(uint256)";
-        (ok,) = address(pool).call(abi.encodeWithSignature(sig, confirmation));
+    function try_deactivate(address pool) external returns(bool ok) {
+        string memory sig = "deactivate()";
+        (ok,) = address(pool).call(abi.encodeWithSignature(sig));
     }
 
     function try_setLiquidityCap(address pool, uint256 liquidityCap) external returns(bool ok) {


### PR DESCRIPTION
# Description
Remove the need for passing in a magic number for deactivating a Pool.

# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog
## Function Signature Changes
`Pool::deactivate(uint256)` -> `Pool::deactivate()`
