### PR TITLE
feat: Remove BFactory from MapleGlobals

### DIFF
--- a/contracts/MapleGlobals.sol
+++ b/contracts/MapleGlobals.sol
@@ -12,7 +12,6 @@ interface ICalc { function calcType() external view returns (uint8); }
 /// @title MapleGlobals maintains a central source of parameters and allowlists for the Maple protocol.
 contract MapleGlobals {
 
-    address public immutable BFactory;   // Official Balancer pool factory
     address public immutable mpl;        // Maple Token is the ERC-2222 token for the Maple protocol
 
     address public pendingGovernor;      // Governor that is declared for transfer, must be accepted for transfer to take effect
@@ -72,10 +71,9 @@ contract MapleGlobals {
         @dev    Constructor function.
         @param  _governor Address of Governor
         @param  _mpl      Address of the ERC-2222 token for the Maple protocol
-        @param  _bFactory The official Balancer pool factory
         @param  _admin    Address that takes care of protocol security switch 
     */
-    constructor(address _governor, address _mpl, address _bFactory, address _admin) public {
+    constructor(address _governor, address _mpl, address _admin) public {
         governor             = _governor;
         mpl                  = _mpl;
         gracePeriod          = 5 days;
@@ -84,7 +82,6 @@ contract MapleGlobals {
         drawdownGracePeriod  = 10 days;
         investorFee          = 50;
         treasuryFee          = 50;
-        BFactory             = _bFactory;
         maxSwapSlippage      = 1000;       // 10 %
         minLoanEquity        = 2000;       // 20 %
         admin                = _admin;

--- a/contracts/PoolFactory.sol
+++ b/contracts/PoolFactory.sol
@@ -3,8 +3,6 @@ pragma solidity 0.6.11;
 
 import "./Pool.sol";
 
-import "./interfaces/IBFactory.sol";
-
 import "lib/openzeppelin-contracts/contracts/utils/Pausable.sol";
 
 /// @title PoolFactory instantiates Pools.
@@ -72,7 +70,6 @@ contract PoolFactory is Pausable {
             require(_globals.isValidSubFactory(address(this), llFactory, LL_FACTORY), "PF:INVALID_LL_FACTORY");
             require(_globals.isValidSubFactory(address(this), slFactory, SL_FACTORY), "PF:INVALID_SL_FACTORY");
             require(_globals.isValidPoolDelegate(msg.sender),                         "PF:INVALID_DELEGATE");
-            require(IBFactory(_globals.BFactory()).isBPool(stakeAsset),               "PF:STAKE_ASSET_NOT_BPOOL");
         }
         
         string memory name   = string(abi.encodePacked("Maple Pool Token"));

--- a/contracts/interfaces/IGlobals.sol
+++ b/contracts/interfaces/IGlobals.sol
@@ -28,10 +28,6 @@ interface IGlobals {
 
     function isValidCollateralAsset(address) external view returns (bool);
 
-    function BFactory() external view returns (address);
-
-    function setBFactory() external view returns (uint256);
-
     function isValidPoolDelegate(address) external view returns (bool);
 
     function validLoanAssets() external view returns (address[] memory);

--- a/contracts/test/Calcs.t.sol
+++ b/contracts/test/Calcs.t.sol
@@ -100,7 +100,7 @@ contract CalcsTest is TestUtil {
         joe            = new PoolDelegate();                                            // Actor: Manager of the Pool.
 
         mpl            = new MapleToken("MapleToken", "MAPL", USDC);
-        globals        = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals        = gov.createGlobals(address(mpl));
         flFactory      = new FundingLockerFactory();                                    // Setup the FL factory to facilitate Loan factory functionality.
         clFactory      = new CollateralLockerFactory();                                 // Setup the CL factory to facilitate Loan factory functionality.
         loanFactory    = new LoanFactory(address(globals));                             // Create Loan factory.

--- a/contracts/test/ChainLinkOracle.t.sol
+++ b/contracts/test/ChainLinkOracle.t.sol
@@ -28,7 +28,7 @@ contract ChainlinkOracleTest is TestUtil {
 
         gov       = new Governor();                                  // Actor: Governor of Maple.
         mpl       = new MapleToken("MapleToken", "MAPL", USDC);      // Setup Maple token.
-        globals   = gov.createGlobals(address(mpl), BPOOL_FACTORY);  // Setup Maple Globals.
+        globals   = gov.createGlobals(address(mpl));                 // Setup Maple Globals.
         admin     = new SecurityAdmin();
         oracle    = new ChainlinkOracle(tokens["WETH"].orcl, address(0), address(admin));
         fakeAdmin = new SecurityAdmin();

--- a/contracts/test/CollateralLockerFactory.t.sol
+++ b/contracts/test/CollateralLockerFactory.t.sol
@@ -25,7 +25,7 @@ contract CollateralLockerFactoryTest is TestUtil {
         gov         = new Governor();                                  // Actor: Governor of Maple.
 
         mpl         = new MapleToken("MapleToken", "MAPL", USDC);      // Setup Maple token.
-        globals     = gov.createGlobals(address(mpl), BPOOL_FACTORY);  // Setup Maple Globals.
+        globals     = gov.createGlobals(address(mpl));                 // Setup Maple Globals.
         clFactory   = new CollateralLockerFactory();                   // Setup Collateral Locker Factory to support Loan Factory creation.
         ali         = new Borrower();
         assertEq(clFactory.factoryType(), uint(0), "Incorrect factory type");

--- a/contracts/test/DebtLockerFactory.t.sol
+++ b/contracts/test/DebtLockerFactory.t.sol
@@ -45,7 +45,7 @@ contract DebtLockerFactoryTest is TestUtil {
         gov       = new Governor();                                  // Actor: Governor of Maple.
 
         mpl       = new MapleToken("MapleToken", "MAPL", USDC);                  // Setup Maple token.
-        globals   = gov.createGlobals(address(mpl), BPOOL_FACTORY);              // Setup Maple Globals.
+        globals   = gov.createGlobals(address(mpl));                             // Setup Maple Globals.
         flFactory = new FundingLockerFactory();                                  // Setup Funding Locker Factory to support Loan Factory creation.
         clFactory = new CollateralLockerFactory();                               // Setup Collateral Locker Factory to support Loan Factory creation.
         lFactory  = new LoanFactory(address(globals));                           // Setup Loan Factory to support Loan creation.

--- a/contracts/test/FundingLockerFactory.t.sol
+++ b/contracts/test/FundingLockerFactory.t.sol
@@ -23,7 +23,7 @@ contract FundingLockerFactoryTest is TestUtil {
         gov       = new Governor();                                  // Actor: Governor of Maple.
 
         mpl       = new MapleToken("MapleToken", "MAPL", USDC);      // Setup Maple token.
-        globals   = gov.createGlobals(address(mpl), BPOOL_FACTORY);  // Setup Maple Globals.
+        globals   = gov.createGlobals(address(mpl));                 // Setup Maple Globals.
         flFactory = new FundingLockerFactory();                      // Setup Funding Locker Factory to support Loan Factory creation.
         assertEq(flFactory.factoryType(), uint(2), "Incorrect factory type");
     }

--- a/contracts/test/Gulp.t.sol
+++ b/contracts/test/Gulp.t.sol
@@ -82,7 +82,7 @@ contract GulpTest is TestUtil {
         dan            = new Staker();                        // Actor: Staker BPTs in Pool.
 
         mpl            = new MapleToken("MapleToken", "MAPL", USDC);
-        globals        = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals        = gov.createGlobals(address(mpl));
         treasury       = new MapleTreasury(address(mpl), USDC, UNISWAP_V2_ROUTER_02, address(globals));
 
         flFactory      = new FundingLockerFactory();          // Setup the FL factory to facilitate Loan factory functionality.

--- a/contracts/test/Loan.t.sol
+++ b/contracts/test/Loan.t.sol
@@ -29,6 +29,7 @@ import "../StakeLockerFactory.sol";
 
 import "../interfaces/IERC20Details.sol";
 import "../interfaces/ILoan.sol";
+import "../interfaces/IBFactory.sol";
 
 import "../oracles/ChainlinkOracle.sol";
 import "../oracles/UsdOracle.sol";
@@ -81,7 +82,7 @@ contract LoanTest is TestUtil {
         mic = new EmergencyAdmin();  // Actor: Emergency Admin of the protocol.
 
         mpl      = new MapleToken("MapleToken", "MAPL", USDC);
-        globals  = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals  = gov.createGlobals(address(mpl));
         treasury = new MapleTreasury(address(mpl), USDC, UNISWAP_V2_ROUTER_02, address(globals));
 
         flFactory     = new FundingLockerFactory();         // Setup the FL factory to facilitate Loan factory functionality.

--- a/contracts/test/LoanFactory.t.sol
+++ b/contracts/test/LoanFactory.t.sol
@@ -49,7 +49,7 @@ contract LoanFactoryTest is TestUtil {
         mic       = new EmergencyAdmin();                            // Actor: Emergency Admin of the protocol.
 
         mpl       = new MapleToken("MapleToken", "MAPL", USDC);      // Setup Maple token.
-        globals   = gov.createGlobals(address(mpl), BPOOL_FACTORY);  // Setup Maple Globals.
+        globals   = gov.createGlobals(address(mpl));                 // Setup Maple Globals.
         flFactory = new FundingLockerFactory();                      // Setup Funding Locker Factory to support Loan Factory creation.
         clFactory = new CollateralLockerFactory();                   // Setup Collateral Locker Factory to support Loan Factory creation.
         lFactory  = new LoanFactory(address(globals));               // Setup Loan Factory to support Loan creation.
@@ -78,13 +78,13 @@ contract LoanFactoryTest is TestUtil {
     function test_setGlobals() public {
         Governor fakeGov = new Governor();
 
-        MapleGlobals globals2 = fakeGov.createGlobals(address(mpl), BPOOL_FACTORY);  // Create upgraded MapleGlobals
+        MapleGlobals globals2 = fakeGov.createGlobals(address(mpl));  // Create upgraded MapleGlobals
 
         assertEq(address(lFactory.globals()), address(globals));
 
         assertTrue(!fakeGov.try_setGlobals(address(lFactory), address(globals2)));  // Non-governor cannot set new globals
 
-        globals2 = gov.createGlobals(address(mpl), BPOOL_FACTORY);      // Create upgraded MapleGlobals
+        globals2 = gov.createGlobals(address(mpl));      // Create upgraded MapleGlobals
 
         assertTrue(gov.try_setGlobals(address(lFactory), address(globals2)));       // Governor can set new globals
         assertEq(address(lFactory.globals()), address(globals2));                   // Globals is updated

--- a/contracts/test/LoanLiquidation.t.sol
+++ b/contracts/test/LoanLiquidation.t.sol
@@ -26,6 +26,7 @@ import "../StakeLockerFactory.sol";
 
 import "../interfaces/IERC20Details.sol";
 import "../interfaces/ILoan.sol";
+import "../interfaces/IBFactory.sol";
 
 import "../oracles/ChainlinkOracle.sol";
 import "../oracles/UsdOracle.sol";
@@ -70,7 +71,7 @@ contract LoanLiquidationTest is TestUtil {
         sid = new PoolDelegate(); // Actor: Manager of the Pool.
 
         mpl      = new MapleToken("MapleToken", "MAPL", USDC);
-        globals  = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals  = gov.createGlobals(address(mpl));
         treasury = new MapleTreasury(address(mpl), USDC, UNISWAP_V2_ROUTER_02, address(globals));
 
         flFactory     = new FundingLockerFactory();         // Setup the FL factory to facilitate Loan factory functionality.

--- a/contracts/test/MapleGlobals.t.sol
+++ b/contracts/test/MapleGlobals.t.sol
@@ -69,7 +69,7 @@ contract MapleGlobalsTest is TestUtil {
         joe         = new PoolDelegate();   // Actor: Manager of the Pool.
 
         mpl           = new MapleToken("MapleToken", "MAPLE", USDC);
-        globals       = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals       = gov.createGlobals(address(mpl));
         poolFactory   = new PoolFactory(address(globals));
         loanFactory   = new LoanFactory(address(globals));
         dlFactory     = new DebtLockerFactory();
@@ -116,7 +116,7 @@ contract MapleGlobalsTest is TestUtil {
 
     function test_constructor() public {
 
-        globals = new MapleGlobals(address(gov), address(mpl), BPOOL_FACTORY, address(1));
+        globals = new MapleGlobals(address(gov), address(mpl), address(1));
 
         assertEq(globals.governor(),         address(gov));
         assertEq(globals.mpl(),              address(mpl));
@@ -126,7 +126,6 @@ contract MapleGlobalsTest is TestUtil {
         assertEq(globals.drawdownGracePeriod(),   10 days);
         assertEq(globals.investorFee(),                50);
         assertEq(globals.treasuryFee(),                50);
-        assertEq(globals.BFactory(),        BPOOL_FACTORY);
         assertEq(globals.maxSwapSlippage(),          1000);
         assertEq(globals.minLoanEquity(),            2000);
         assertEq(globals.admin(),              address(1));

--- a/contracts/test/MapleTreasury.t.sol
+++ b/contracts/test/MapleTreasury.t.sol
@@ -36,7 +36,7 @@ contract MapleTreasuryTest is TestUtil {
         fakeGov = new Governor();
 
         mpl      = new MapleToken("MapleToken", "MAPLE", USDC);
-        globals  = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals  = gov.createGlobals(address(mpl));
         treasury = new MapleTreasury(address(mpl), USDC, UNISWAP_V2_ROUTER_02, address(globals)); 
 
         // Set test util governor storage var
@@ -63,13 +63,13 @@ contract MapleTreasuryTest is TestUtil {
     }
 
     function test_setGlobals() public {
-        MapleGlobals globals2 = fakeGov.createGlobals(address(mpl), BPOOL_FACTORY);  // Create upgraded MapleGlobals
+        MapleGlobals globals2 = fakeGov.createGlobals(address(mpl));                // Create upgraded MapleGlobals
 
         assertEq(address(treasury.globals()), address(globals));
 
         assertTrue(!fakeGov.try_setGlobals(address(treasury), address(globals2)));  // Non-governor cannot set new globals
 
-        globals2 = gov.createGlobals(address(mpl), BPOOL_FACTORY);                  // Create upgraded MapleGlobals
+        globals2 = gov.createGlobals(address(mpl));                                 // Create upgraded MapleGlobals
 
         assertTrue(gov.try_setGlobals(address(treasury), address(globals2)));       // Governor can set new globals
         assertEq(address(treasury.globals()), address(globals2));                   // Globals is updated

--- a/contracts/test/MplRewards.t.sol
+++ b/contracts/test/MplRewards.t.sol
@@ -15,6 +15,8 @@ import "../Pool.sol";
 import "../PoolFactory.sol";
 import "../StakeLockerFactory.sol";
 
+import "../interfaces/IBFactory.sol";
+
 import "module/maple-token/contracts/MapleToken.sol";
 
 contract MplRewardsTest is TestUtil {
@@ -49,7 +51,7 @@ contract MplRewardsTest is TestUtil {
         sid     = new PoolDelegate();                // Actor: Manager of the Pool.
 
         mpl         = new MapleToken("MapleToken", "MAPL", USDC);
-        globals     = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals     = gov.createGlobals(address(mpl));
         slFactory   = new StakeLockerFactory();                        // Setup the SL factory to facilitate Pool factory functionality.
         llFactory   = new LiquidityLockerFactory();                    // Setup the SL factory to facilitate Pool factory functionality.
         poolFactory = new PoolFactory(address(globals));               // Create pool factory.

--- a/contracts/test/MplRewardsFactory.t.sol
+++ b/contracts/test/MplRewardsFactory.t.sol
@@ -24,7 +24,7 @@ contract MplRewardsFactoryTest is TestUtil {
         gov      = new Governor();                                  // Actor: Governor of Maple.
         fakeGov  = new Governor();                                  // Actor: Fake Governor of Maple.
         mpl      = new MapleToken("MapleToken", "MAPL", USDC);      // Setup Maple token.
-        globals  = gov.createGlobals(address(mpl), BPOOL_FACTORY);  // Setup Maple Globals.
+        globals  = gov.createGlobals(address(mpl));                 // Setup Maple Globals.
 
         mplRewardsFactory = gov.createMplRewardsFactory();
 

--- a/contracts/test/Pool.t.sol
+++ b/contracts/test/Pool.t.sol
@@ -109,7 +109,7 @@ contract PoolTest is TestUtil {
         mic            = new EmergencyAdmin();                                          // Actor: Emergency Admin of the protocol.
 
         mpl            = new MapleToken("MapleToken", "MAPL", USDC);
-        globals        = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals        = gov.createGlobals(address(mpl));
         flFactory      = new FundingLockerFactory();                                    // Setup the FL factory to facilitate Loan factory functionality.
         clFactory      = new CollateralLockerFactory();                                 // Setup the CL factory to facilitate Loan factory functionality.
         loanFactory    = new LoanFactory(address(globals));                             // Create Loan factory.

--- a/contracts/test/PoolExcess.t.sol
+++ b/contracts/test/PoolExcess.t.sol
@@ -87,7 +87,7 @@ contract PoolExcessTest is TestUtil {
         dan            = new Staker();                       // Actor: Stakes BPTs in Pool.
 
         mpl            = new MapleToken("MapleToken", "MAPL", USDC);
-        globals        = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals        = gov.createGlobals(address(mpl));
         flFactory      = new FundingLockerFactory();         // Setup the FL factory to facilitate Loan factory functionality.
         clFactory      = new CollateralLockerFactory();      // Setup the CL factory to facilitate Loan factory functionality.
         loanFactory    = new LoanFactory(address(globals));  // Create Loan factory.

--- a/contracts/test/PoolFactory.t.sol
+++ b/contracts/test/PoolFactory.t.sol
@@ -47,7 +47,7 @@ contract PoolFactoryTest is TestUtil {
         mic         = new EmergencyAdmin(); // Actor: Emergency Admin of the protocol.
 
         mpl         = new MapleToken("MapleToken", "MAPL", USDC);
-        globals     = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals     = gov.createGlobals(address(mpl));
         slFactory   = new StakeLockerFactory();
         llFactory   = new LiquidityLockerFactory();
         poolFactory = new PoolFactory(address(globals));
@@ -89,13 +89,13 @@ contract PoolFactoryTest is TestUtil {
     function test_setGlobals() public {
         Governor fakeGov = new Governor();
 
-        MapleGlobals globals2 = fakeGov.createGlobals(address(mpl), BPOOL_FACTORY);  // Create upgraded MapleGlobals
+        MapleGlobals globals2 = fakeGov.createGlobals(address(mpl));                   // Create upgraded MapleGlobals
 
         assertEq(address(poolFactory.globals()), address(globals));
 
         assertTrue(!fakeGov.try_setGlobals(address(poolFactory), address(globals2)));  // Non-governor cannot set new globals
 
-        globals2 = gov.createGlobals(address(mpl), BPOOL_FACTORY);                     // Create upgraded MapleGlobals
+        globals2 = gov.createGlobals(address(mpl));                                    // Create upgraded MapleGlobals
 
         assertTrue(gov.try_setGlobals(address(poolFactory), address(globals2)));       // Governor can set new globals
         assertEq(address(poolFactory.globals()), address(globals2));                   // Globals is updated

--- a/contracts/test/PoolLiquidation.t.sol
+++ b/contracts/test/PoolLiquidation.t.sol
@@ -96,7 +96,7 @@ contract PoolLiquidationTest is TestUtil {
         mic            = new EmergencyAdmin();               // Actor: Emergency Admin of the protocol.
 
         mpl            = new MapleToken("MapleToken", "MAPL", USDC);
-        globals        = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals        = gov.createGlobals(address(mpl));
         flFactory      = new FundingLockerFactory();         // Setup the FL factory to facilitate Loan factory functionality.
         clFactory      = new CollateralLockerFactory();      // Setup the CL factory to facilitate Loan factory functionality.
         loanFactory    = new LoanFactory(address(globals));  // Create Loan factory.

--- a/contracts/test/StakeLocker.t.sol
+++ b/contracts/test/StakeLocker.t.sol
@@ -90,7 +90,7 @@ contract StakeLockerTest is TestUtil {
         mic            = new EmergencyAdmin();                                          // Actor: Emergency Admin of the protocol.
 
         mpl            = new MapleToken("MapleToken", "MAPL", USDC);
-        globals        = gov.createGlobals(address(mpl), BPOOL_FACTORY);
+        globals        = gov.createGlobals(address(mpl));
         flFactory      = new FundingLockerFactory();                                    // Setup the FL factory to facilitate Loan factory functionality.
         clFactory      = new CollateralLockerFactory();                                 // Setup the CL factory to facilitate Loan factory functionality.
         loanFactory    = new LoanFactory(address(globals));                             // Create Loan factory.

--- a/contracts/test/StakeLockerFactory.t.sol
+++ b/contracts/test/StakeLockerFactory.t.sol
@@ -24,7 +24,7 @@ contract StakeLockerFactoryTest is TestUtil {
         gov       = new Governor();                                  // Actor: Governor of Maple.
 
         mpl       = new MapleToken("MapleToken", "MAPL", USDC);      // Setup Maple token.
-        globals   = gov.createGlobals(address(mpl), BPOOL_FACTORY);  // Setup Maple Globals.
+        globals   = gov.createGlobals(address(mpl));                 // Setup Maple Globals.
         slFactory = new StakeLockerFactory();                        // Setup Stake Locker Factory to support Stake Locker creation.
         assertEq(slFactory.factoryType(), uint(4), "Incorrect factory type");
     }

--- a/contracts/test/user/Governor.sol
+++ b/contracts/test/user/Governor.sol
@@ -18,8 +18,8 @@ contract Governor {
     MplRewardsFactory mplRewardsFactory;
     MapleTreasury     treasury;
 
-    function createGlobals(address mpl, address bPoolFactory) external returns (MapleGlobals) {
-        globals = new MapleGlobals(address(this), mpl, bPoolFactory, address(1));
+    function createGlobals(address mpl) external returns (MapleGlobals) {
+        globals = new MapleGlobals(address(this), mpl, address(1));
         return globals;
     }
 


### PR DESCRIPTION
# Description
Remove Balancer Factory from `MapleGlobals` since we’re now whitelisting Balancer Pools and no longer need to call `isBPool()`.

# Integrations Checklist

- [x] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog
## Function Signature Changes
`MapleGlobals::constructor(address,address,address,address)` -> `MapleGlobals::constructor(address,address,address)`
