### PR TITLE
chore: NatSpec C4 fixes and normalization (SC-2032)

### DIFF
--- a/contracts/CollateralLocker.sol
+++ b/contracts/CollateralLocker.sol
@@ -16,13 +16,16 @@ contract CollateralLocker {
         loan            = _loan;
     }
 
+    /**
+        @dev Checks that msg.sender is the Loan.
+    */
     modifier isLoan() {
         require(msg.sender == loan, "CollateralLocker:MSG_SENDER_NOT_LOAN");
         _;
     }
 
     /**
-        @dev Transfers amt of collateralAsset to dst. Only Loan can call this function.
+        @dev Transfers amt of collateralAsset to dst. Only the Loan can call this function.
         @param dst Desintation to transfer collateralAsset to
         @param amt Amount of collateralAsset to transfer
     */

--- a/contracts/DebtLocker.sol
+++ b/contracts/DebtLocker.sol
@@ -42,7 +42,7 @@ contract DebtLocker {
     }
 
     /**
-        @dev    Claim funds distribution for Loan via FDT.
+        @dev    Claim funds distribution for Loan via FDT. Only called by the pool contract.
         @return [0] = Total Claimed
                 [1] = Interest Claimed
                 [2] = Principal Claimed

--- a/contracts/DebtLocker.sol
+++ b/contracts/DebtLocker.sol
@@ -25,6 +25,9 @@ contract DebtLocker {
     uint256 public lastDefaultSuffered;  // Loan total default suffered at last time claim() was called
     uint256 public lastAmountRecovered;  // Liquidity asset (a.k.a. loan asset) recovered from liquidation of Loan collateral
 
+    /**
+        @dev Checks that msg.sender is the Pool.
+    */
     modifier isPool() {
         require(msg.sender == pool, "DebtLocker:MSG_SENDER_NOT_POOL");
         _;
@@ -42,7 +45,7 @@ contract DebtLocker {
     }
 
     /**
-        @dev    Claim funds distribution for Loan via FDT. Only called by the pool contract.
+        @dev    Claim funds distribution for Loan via FDT. Only the Pool can call this function.
         @return [0] = Total Claimed
                 [1] = Interest Claimed
                 [2] = Principal Claimed
@@ -119,7 +122,7 @@ contract DebtLocker {
     }
 
     /**
-        @dev Liquidate a loan that is held by this contract. Only called by the pool contract.
+        @dev Liquidate a loan that is held by this contract. Only the Pool can call this function.
     */
     function triggerDefault() external isPool {
         loan.triggerDefault();

--- a/contracts/FundingLocker.sol
+++ b/contracts/FundingLocker.sol
@@ -16,6 +16,9 @@ contract FundingLocker {
         loan           = _loan;
     }
 
+    /**
+        @dev Checks that msg.sender is the Loan.
+    */
     modifier isLoan() {
         require(msg.sender == loan, "FundingLocker:MSG_SENDER_NOT_LOAN");
         _;

--- a/contracts/LiquidityLocker.sol
+++ b/contracts/LiquidityLocker.sol
@@ -18,6 +18,9 @@ contract LiquidityLocker {
         pool           = _pool;
     }
 
+    /**
+        @dev Checks that msg.sender is the Pool.
+    */
     modifier isPool() {
         require(msg.sender == pool, "LiquidityLocker:MSG_SENDER_NOT_POOL");
         _;

--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -179,7 +179,7 @@ contract Loan is FDT, Pausable {
     /**************************/
 
     /**
-        @dev Drawdown funding from FundingLocker, post collateral, and transition loanState from `Ready` to `Active`.
+        @dev Drawdown funding from FundingLocker, post collateral, and transition loanState from `Ready` to `Active`. Only the Loan Borrower can call this function.
         @param amt Amount of liquidityAsset borrower draws down, remainder is returned to Loan where it can be claimed back by LoanFDT holders.
     */
     function drawdown(uint256 amt) external {
@@ -306,7 +306,8 @@ contract Loan is FDT, Pausable {
     /************************/
 
     /**
-        @dev Fund this loan and mint LoanFDTs for mintTo (DebtLocker in the case of Pool funding)
+        @dev Fund this loan and mint LoanFDTs for mintTo (DebtLocker in the case of Pool funding).
+             Only Liquidity Locker using valid/approved Pool can call this function.
         @param  amt    Amount to fund the loan
         @param  mintTo Address that LoanFDTs are minted to
     */
@@ -344,6 +345,7 @@ contract Loan is FDT, Pausable {
 
     /**
         @dev Trigger a default if a Loan is in a condition where a default can be triggered, liquidating all collateral and updating accounting.
+             Only the Loan can call this function.
     */
     function triggerDefault() external {
         _whenProtocolNotPaused();
@@ -386,7 +388,7 @@ contract Loan is FDT, Pausable {
     /***********************/
 
     /**
-        @dev Triggers paused state. Halts functionality for certain functions.
+        @dev Triggers paused state. Halts functionality for certain functions. Only the Loan Borrower or a Loan Admin can call this function.
     */
     function pause() external {
         _isValidBorrowerOrAdmin();
@@ -394,7 +396,7 @@ contract Loan is FDT, Pausable {
     }
 
     /**
-        @dev Triggers unpaused state. Returns functionality for certain functions.
+        @dev Triggers unpaused state. Returns functionality for certain functions. Only the Loan Borrower or a Loan Admin can call this function.
     */
     function unpause() external {
         _isValidBorrowerOrAdmin();
@@ -402,7 +404,7 @@ contract Loan is FDT, Pausable {
     }
 
     /**
-        @dev Set admin.
+        @dev Set admin. Only the Loan Borrower can call this function.
         @param newAdmin New admin address
         @param allowed  Status of an admin
     */
@@ -417,7 +419,7 @@ contract Loan is FDT, Pausable {
     /**************************/
 
     /**
-        @dev Transfer any locked funds to the governor.
+        @dev Transfer any locked funds to the governor. Only the Governor can call this function.
         @param token Address of the token that need to reclaimed.
      */
     function reclaimERC20(address token) external {
@@ -498,7 +500,7 @@ contract Loan is FDT, Pausable {
     }
 
     /**
-        @dev Function to determine if msg.sender is eligible to trigger pause/unpause.
+        @dev Checks that msg.sender is the Loan Borrower or a Loan Admin.
     */
     function _isValidBorrowerOrAdmin() internal {
         require(msg.sender == borrower || admins[msg.sender], "Pool:UNAUTHORIZED");
@@ -541,14 +543,14 @@ contract Loan is FDT, Pausable {
     }
 
     /**
-        @dev Utility to return if msg.sender is the Loan borrower.
+        @dev Checks that msg.sender is the Loan Borrower.
     */
     function _isValidBorrower() internal view {
         require(msg.sender == borrower, "Loan:INVALID_BORROWER");
     }
 
     /**
-        @dev Utility to return if lender is using an approved Pool to fund the loan.
+        @dev Checks that msg.sender is a Lender (Liquidity Locker) that is using an approved Pool to fund the loan.
     */
     function _isValidPool() internal view {
         address pool        = ILiquidityLocker(msg.sender).pool();

--- a/contracts/LoanFactory.sol
+++ b/contracts/LoanFactory.sol
@@ -44,7 +44,7 @@ contract LoanFactory is Pausable {
     }
 
     /**
-        @dev Update the MapleGlobals contract
+        @dev Update the MapleGlobals contract. Only the Governor can call this function.
         @param newGlobals Address of new MapleGlobals contract
     */
     function setGlobals(address newGlobals) external {
@@ -121,7 +121,7 @@ contract LoanFactory is Pausable {
     }
 
     /**
-        @dev Set admin.
+        @dev Set admin. Only the Governor can call this function.
         @param newAdmin New admin address
         @param allowed  Status of an admin
     */
@@ -131,7 +131,7 @@ contract LoanFactory is Pausable {
     }
 
     /**
-        @dev Triggers paused state. Halts functionality for certain functions. Only Governor or Loan Factory Admins can call this function.
+        @dev Triggers paused state. Halts functionality for certain functions. Only the Governor or a Loan Factory Admin can call this function.
     */
     function pause() external {
         _isValidGovernorOrAdmin();
@@ -139,7 +139,7 @@ contract LoanFactory is Pausable {
     }
 
     /**
-        @dev Triggers unpaused state. Returns functionality for certain functions. Only Governor can call this function.
+        @dev Triggers unpaused state. Returns functionality for certain functions. Only the Governor or a Loan Factory Admin can call this function.
     */
     function unpause() external {
         _isValidGovernorOrAdmin();
@@ -147,14 +147,14 @@ contract LoanFactory is Pausable {
     }
 
     /**
-        @dev Function to determine if msg.sender is Governor.
+        @dev Checks that msg.sender is the Governor.
     */
     function _isValidGovernor() internal view {
         require(msg.sender == globals.governor(), "PoolFactory:INVALID_GOVERNOR");
     }
 
     /**
-        @dev Function to determine if msg.sender is Governor or a Loan Factory Admin.
+        @dev Checks that msg.sender is the Governor or a Loan Factory Admin.
     */
     function _isValidGovernorOrAdmin() internal {
         require(msg.sender == globals.governor() || admins[msg.sender], "PoolFactory:UNAUTHORIZED");

--- a/contracts/LoanFactory.sol
+++ b/contracts/LoanFactory.sol
@@ -131,7 +131,7 @@ contract LoanFactory is Pausable {
     }
 
     /**
-        @dev Triggers paused state. Halts functionality for certain functions. Only Governor can call this function.
+        @dev Triggers paused state. Halts functionality for certain functions. Only Governor or Loan Factory Admins can call this function.
     */
     function pause() external {
         _isValidGovernorOrAdmin();
@@ -147,21 +147,21 @@ contract LoanFactory is Pausable {
     }
 
     /**
-        @dev Function to determine if msg.sender is eligible to trigger pause/unpause.
+        @dev Function to determine if msg.sender is Governor.
     */
     function _isValidGovernor() internal view {
         require(msg.sender == globals.governor(), "PoolFactory:INVALID_GOVERNOR");
     }
 
     /**
-        @dev Function to determine if msg.sender is eligible to trigger pause/unpause.
+        @dev Function to determine if msg.sender is Governor or a Loan Factory Admin.
     */
     function _isValidGovernorOrAdmin() internal {
         require(msg.sender == globals.governor() || admins[msg.sender], "PoolFactory:UNAUTHORIZED");
     }
 
     /**
-        @dev Function to determine if msg.sender is eligible to trigger pause/unpause.
+        @dev Function to determine if protocol is paused/unpaused.
     */
     function _whenProtocolNotPaused() internal {
         require(!globals.protocolPaused(), "PoolFactory:PROTOCOL_PAUSED");

--- a/contracts/MapleGlobals.sol
+++ b/contracts/MapleGlobals.sol
@@ -66,6 +66,9 @@ contract MapleGlobals {
     event               GlobalsAddressSet(bytes32 indexed which, address addr);
     event                  ProtocolPaused(bool pause);
 
+    /**
+        @dev Checks that msg.sender is the Governor.
+    */
     modifier isGovernor() {
         require(msg.sender == governor, "MapleGlobals:MSG_SENDER_NOT_GOVERNOR");
         _;
@@ -101,15 +104,17 @@ contract MapleGlobals {
 
     /**
         @dev Update the `stakerCooldownPeriod` state variable. This change will affect existing cool down period for the stakers who already intended to unstake.
+             Only the Governor can call this function.
         @param newCooldownPeriod New value for the cool down period.
      */
-        function setStakerCooldownPeriod(uint256 newCooldownPeriod) external isGovernor {
+    function setStakerCooldownPeriod(uint256 newCooldownPeriod) external isGovernor {
         stakerCooldownPeriod = newCooldownPeriod;
         emit GlobalsParamSet("STAKER_COOLDOWN_PERIOD", newCooldownPeriod);
     }
 
     /**
         @dev Update the `lpCooldownPeriod` state variable. This change will affect existing cool down period for the LPs who already intended to withdraw.
+             Only the Governor can call this function.
         @param newCooldownPeriod New value for the cool down period.
      */
     function setLpCooldownPeriod(uint256 newCooldownPeriod) external isGovernor {
@@ -119,6 +124,7 @@ contract MapleGlobals {
 
     /**
         @dev Update the `stakerUnstakeWindow` state variable. This change will affect existing window for the stalers who already applied to unstake.
+             Only the Governor can call this function.
         @param newUnstakeWindow New value for the unstake window.
      */
     function setStakerUnstakeWindow(uint256 newUnstakeWindow) external isGovernor {
@@ -128,6 +134,7 @@ contract MapleGlobals {
 
     /**
         @dev Update the `lpWithdrawWindow` state variable. This change will affect existing window for the LPs who already intended to withdraw.
+             Only the Governor can call this function.
         @param newLpWithdrawWindow New value for the withdraw window.
      */
     function setLpWithdrawWindow(uint256 newLpWithdrawWindow) external isGovernor {
@@ -136,7 +143,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Update the allowed Uniswap slippage percentage, in basis points. Only Governor can call.
+        @dev Update the allowed Uniswap slippage percentage, in basis points. Only the Governor can call this function.
         @param newMaxSlippage New max slippage percentage (in basis points)
      */
     function setMaxSwapSlippage(uint256 newMaxSlippage) external isGovernor {
@@ -146,7 +153,7 @@ contract MapleGlobals {
     }
 
     /**
-      @dev Set admin.
+      @dev Set admin. Only the Governor can call this function.
       @param newAdmin New admin address
      */
     function setAdmin(address newAdmin) external {
@@ -157,8 +164,8 @@ contract MapleGlobals {
 
     /**
         @dev Update the allowlist for contracts that will be excempt from transfer restrictions (lockup and cooldown).
-        These addresses are reserved for DeFi composability such as yield farming, collateral-based lending on other platforms, etc.
-        Only Governor can call.
+             These addresses are reserved for DeFi composability such as yield farming, collateral-based lending on other platforms, etc.
+             Only the Governor can call this function.
         @param addr  Address of exempt contract.
         @param valid The new bool value for validating addr.
     */
@@ -168,7 +175,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Update the valid Balancer Pool mapping. Only Governor can call.
+        @dev Update the valid Balancer Pool mapping. Only the Governor can call this function.
         @param balancerPool Address of Balancer Pool contract.
         @param valid        The new bool value for validating Balancer Pool.
     */
@@ -178,9 +185,9 @@ contract MapleGlobals {
     }
 
     /**
-      @dev Pause/unpause the protocol. Only admin user can call.
+      @dev Pause/unpause the protocol. Only the Admin user can call.
       @param pause Boolean flag to switch externally facing functionality in the protocol on/off
-     */
+    */
     function setProtocolPause(bool pause) external {
         require(msg.sender == admin, "MapleGlobals:UNAUTHORIZED");
         protocolPaused = pause;
@@ -188,7 +195,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Update the valid PoolFactory mapping. Only Governor can call.
+        @dev Update the valid PoolFactory mapping. Only the Governor can call this function.
         @param poolFactory Address of PoolFactory
         @param valid       The new bool value for validating poolFactory
     */
@@ -197,7 +204,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Update the valid LoanFactory mapping. Only Governor can call.
+        @dev Update the valid LoanFactory mapping. Only the Governor can call this function.
         @param loanFactory Address of LoanFactory
         @param valid       The new bool value for validating loanFactory.
     */
@@ -206,7 +213,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Set the validity of a subFactory as it relates to a superFactory. Only Governor can call.
+        @dev Set the validity of a subFactory as it relates to a superFactory. Only the Governor can call this function.
         @param superFactory The core factory (e.g. PoolFactory, LoanFactory)
         @param subFactory   The sub factory used by core factory (e.g. LiquidityLockerFactory)
         @param valid        The validity of subFactory within context of superFactory
@@ -217,7 +224,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Set the path to swap an asset through Uniswap. Only Governor can call.
+        @dev Set the path to swap an asset through Uniswap. Only the Governor can call this function.
         @param from Asset being swapped
         @param to   Final asset to receive **
         @param mid  Middle asset
@@ -230,7 +237,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Update validity of Pool Delegate (those allowed to create Pools). Only Governor can call.
+        @dev Update validity of Pool Delegate (those allowed to create Pools). Only the Governor can call this function.
         @param delegate Address to manage permissions for
         @param valid    New permissions of address
     */
@@ -239,7 +246,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Set the validity of an asset for collateral. Only Governor can call.
+        @dev Set the validity of an asset for collateral. Only the Governor can call this function.
         @param asset The asset to assign validity to
         @param valid The new validity of asset as collateral
     */
@@ -249,7 +256,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Set the validity of an asset for loans/liquidity in Pools. Only Governor can call.
+        @dev Set the validity of an asset for loans/liquidity in Pools. Only the Governor can call this function.
         @param asset Address of the valid asset
         @param valid The new validity of asset for loans/liquidity in Pools
     */
@@ -259,7 +266,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Specifiy validity of a calculator contract. Only Governor can call.
+        @dev Specifiy validity of a calculator contract. Only the Governor can call this function.
         @param  calc  Calculator address
         @param  valid Validity of calculator
     */
@@ -268,7 +275,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Adjust investorFee (in basis points). Only Governor can call.
+        @dev Adjust investorFee (in basis points). Only the Governor can call this function.
         @param _fee The fee, e.g., 50 = 0.50%
     */
     function setInvestorFee(uint256 _fee) external isGovernor {
@@ -279,7 +286,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Adjust treasuryFee (in basis points). Only Governor can call.
+        @dev Adjust treasuryFee (in basis points). Only the Governor can call this function.
         @param _fee The fee, e.g., 50 = 0.50%
     */
     function setTreasuryFee(uint256 _fee) external isGovernor {
@@ -290,7 +297,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Set the MapleTreasury contract. Only Governor can call.
+        @dev Set the MapleTreasury contract. Only the Governor can call this function.
         @param _mapleTreasury New MapleTreasury address
     */
     function setMapleTreasury(address _mapleTreasury) external isGovernor {
@@ -300,7 +307,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Adjust defaultGracePeriod. Only Governor can call.
+        @dev Adjust defaultGracePeriod. Only the Governor can call this function.
         @param _defaultGracePeriod Number of seconds to set the grace period to
     */
     function setDefaultGracePeriod(uint256 _defaultGracePeriod) external isGovernor {
@@ -309,7 +316,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Adjust minLoanEquity. Only Governor can call.
+        @dev Adjust minLoanEquity. Only the Governor can call this function.
         @param _minLoanEquity Min percentage of Loan equity an address must have to trigger liquidations.
     */
     function setMinLoanEquity(uint256 _minLoanEquity) external isGovernor {
@@ -319,7 +326,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Adjust fundingPeriod. Only Governor can call.
+        @dev Adjust fundingPeriod. Only the Governor can call this function.
         @param _fundingPeriod Number of seconds to set the drawdown grace period to
     */
     function setFundingPeriod(uint256 _fundingPeriod) external isGovernor {
@@ -328,7 +335,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Adjust the minimum Pool cover required to finalize a Pool. Only Governor can call.
+        @dev Adjust the minimum Pool cover required to finalize a Pool. Only the Governor can call this function.
         @param amt The new minimum swap out required
     */
     function setSwapOutRequired(uint256 amt) external isGovernor {
@@ -338,7 +345,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Update a price feed's oracle.
+        @dev Update a price feed's oracle. Only the Governor can call this function.
         @param asset  Asset to update price for
         @param oracle New oracle to use
     */
@@ -352,7 +359,7 @@ contract MapleGlobals {
     /************************************/
 
     /**
-        @dev Set a new pending Governor. This address can become governor if they accept. Only Governor can call.
+        @dev Set a new pending Governor. This address can become governor if they accept. Only the Governor can call this function.
         @param _pendingGovernor Address of new Governor
     */
     function setPendingGovernor(address _pendingGovernor) external isGovernor {
@@ -362,7 +369,7 @@ contract MapleGlobals {
     }
 
     /**
-        @dev Accept the Governor position. Only PendingGovernor can call.
+        @dev Accept the Governor position. Only the Pending Governor can call this function.
     */
     function acceptGovernor() external {
         require(msg.sender == pendingGovernor, "MapleGlobals:NOT_PENDING_GOVERNOR");

--- a/contracts/MapleTreasury.sol
+++ b/contracts/MapleTreasury.sol
@@ -45,13 +45,16 @@ contract MapleTreasury {
     event ERC20Reclaimed(address indexed asset, uint256 amount);
     event FundsTokenModified(address by, address newFundsToken);
 
+    /**
+        @dev Checks that msg.sender is the Governor.
+    */
     modifier isGovernor() {
         require(msg.sender == IGlobals(globals).governor(), "MapleTreasury:MSG_SENDER_NOT_GOVERNOR");
         _;
     }
 
     /**
-        @dev Update the MapleGlobals contract. Only Governor can set
+        @dev Update the MapleGlobals contract. Only the Governor can call this function.
         @param newGlobals Address of new MapleGlobals contract
     */
     function setGlobals(address newGlobals) external isGovernor {
@@ -59,7 +62,7 @@ contract MapleTreasury {
     }
 
     /**
-        @dev Reclaim treasury funds to the MapleDAO address. Only Governor can call.
+        @dev Reclaim treasury funds to the MapleDAO address. Only the Governor can call this function.
         @param asset  Address of the token that need to be reclaimed from the treasury contract
         @param amount Amount to withdraw
     */
@@ -70,6 +73,7 @@ contract MapleTreasury {
 
     /**
         @dev Passes through the current fundsToken balance of the treasury to MapleToken, where it can be claimed by MPL holders.
+             Only the Governor can call this function.
     */
     function distributeToHolders() isGovernor public {
         IERC20 _fundsToken = IERC20(fundsToken);
@@ -80,7 +84,7 @@ contract MapleTreasury {
     }
 
     /**
-        @dev Convert an ERC-20 asset through Uniswap to fundsToken.
+        @dev Convert an ERC-20 asset through Uniswap to fundsToken. Only the Governor can call this function.
         @param asset The ERC-20 asset to convert to fundsToken
     */
     function convertERC20(address asset) isGovernor public {

--- a/contracts/MplRewards.sol
+++ b/contracts/MplRewards.sol
@@ -157,7 +157,7 @@ contract MplRewards is Ownable {
     }
 
     /**
-        @dev Added to support recovering LP Rewards from other systems such as BAL to be distributed to holders.
+        @dev Added to support recovering tokens unintentionally sent to this contract by users.
              Only the contract Owner may call this.
     */
     function recoverERC20(address tokenAddress, uint256 tokenAmount) external onlyOwner {

--- a/contracts/MplRewards.sol
+++ b/contracts/MplRewards.sol
@@ -123,6 +123,9 @@ contract MplRewards is Ownable {
         getReward();
     }
 
+    /**
+        @dev Only the contract Owner may call this.
+    */
     function notifyRewardAmount(uint256 reward) external onlyOwner {
         _updateReward(address(0));
         if (block.timestamp >= periodFinish) {
@@ -145,19 +148,27 @@ contract MplRewards is Ownable {
         emit RewardAdded(reward);
     }
 
-    // End rewards emission earlier
+    /**
+        @dev End rewards emission earlier. Only the contract Owner may call this.
+    */
     function updatePeriodFinish(uint timestamp) external onlyOwner {
         _updateReward(address(0));
         periodFinish = timestamp;
     }
 
-    // Added to support recovering LP Rewards from other systems such as BAL to be distributed to holders
+    /**
+        @dev Added to support recovering LP Rewards from other systems such as BAL to be distributed to holders.
+             Only the contract Owner may call this.
+    */
     function recoverERC20(address tokenAddress, uint256 tokenAmount) external onlyOwner {
         require(tokenAddress != address(stakingToken), "REWARDS:CANNOT_RECOVER_STAKE_TOKEN");
         IERC20(tokenAddress).safeTransfer(owner(), tokenAmount);
         emit Recovered(tokenAddress, tokenAmount);
     }
 
+    /**
+        @dev Only the contract Owner may call this.
+    */
     function setRewardsDuration(uint256 _rewardsDuration) external onlyOwner {
         require(block.timestamp > periodFinish, "REWARDS:PERIOD_NOT_FINISHED");
         rewardsDuration = _rewardsDuration;
@@ -165,7 +176,7 @@ contract MplRewards is Ownable {
     }
 
     /**
-        @dev Change the paused state of the contract. Only the contract owner may call this.
+        @dev Change the paused state of the contract. Only the contract Owner may call this.
     */
     function setPaused(bool _paused) external onlyOwner {
         // Ensure we're actually changing the state before we do anything

--- a/contracts/MplRewardsFactory.sol
+++ b/contracts/MplRewardsFactory.sol
@@ -18,7 +18,7 @@ contract MplRewardsFactory {
     }
 
     /**
-        @dev Update the MapleGlobals contract
+        @dev Update the MapleGlobals contract. Only the Governor can call this function.
         @param _globals Address of new MapleGlobals contract
     */
     function setGlobals(address _globals) external {
@@ -27,7 +27,7 @@ contract MplRewardsFactory {
     }
 
     /**
-        @dev Instantiate a MplRewards contract.
+        @dev Instantiate a MplRewards contract. Only the Governor can call this function.
         @param rewardsToken Address of the rewardsToken (will always be MPL)
         @param stakingToken Address of the stakingToken (token used to stake to earn rewards)
                             (i.e., Pool address for PoolFDT mining, StakeLocker address for staked BPT mining)

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -327,7 +327,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Set admin
+        @dev Set admin. Can only be called by the Pool Delegate.
         @param newAdmin new admin address.
         @param allowed Status of an admin.
     */
@@ -594,7 +594,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Function to determine if msg.sender is eligible to setLiquidityCap for security reasons.
+        @dev Function to determine if msg.sender is Pool Delegate or a Pool Admin.
     */
     function _isValidDelegateOrAdmin() internal {
         require(msg.sender == poolDelegate || admins[msg.sender], "Pool:UNAUTHORIZED");

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -134,7 +134,7 @@ contract Pool is PoolFDT {
     /*******************************/
 
     /**
-        @dev Finalize the Pool, enabling deposits. Checks Pool Delegate amount deposited to StakeLocker.
+        @dev Finalize the Pool, enabling deposits. Checks Pool Delegate amount deposited to StakeLocker. Only the Pool Delegate can call this function.
     */
     function finalize() external {
         _isValidDelegateAndProtocolNotPaused();
@@ -146,7 +146,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Fund a loan for amt, utilize the supplied dlFactory for debt lockers.
+        @dev Fund a loan for amt, utilize the supplied dlFactory for debt lockers. Only the Pool Delegate can call this function.
         @param  loan      Address of the loan to fund
         @param  dlFactory The DebtLockerFactory to utilize
         @param  amt       Amount to fund the loan
@@ -161,7 +161,8 @@ contract Pool is PoolFDT {
 
     /**
         @dev Liquidate the loan. Pool delegate could liquidate a loan only when loan completes its grace period.
-        Pool delegate can claim its proportion of recovered funds from liquidation using the `claim()` function.
+             Pool delegate can claim its proportion of recovered funds from liquidation using the `claim()` function.
+             Only the Pool Delegate can call this function.
         @param loan      Address of the loan contract to liquidate
         @param dlFactory Address of the debt locker factory that is used to pull corresponding debt locker
      */
@@ -171,7 +172,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Claim available funds for loan through specified DebtLockerFactory.
+        @dev Claim available funds for loan through specified DebtLockerFactory. Only the Pool Delegate or a Pool Admin can call this function.
         @param  loan      Address of the loan to claim from
         @param  dlFactory The DebtLockerFactory (always maps to a single debt locker)
         @return [0] = Total amount claimed
@@ -258,7 +259,8 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Pool Delegate triggers deactivation, permanently shutting down the pool. Must have less than 100 USD worth of liquidityAsset principalOut.
+        @dev Triggers deactivation, permanently shutting down the pool. Must have less than 100 USD worth of liquidityAsset principalOut.
+             Only the Pool Delegate can call this function.
     */
     function deactivate() external {
         _isValidDelegateAndProtocolNotPaused();
@@ -273,7 +275,7 @@ contract Pool is PoolFDT {
     /**************************************/
 
     /**
-        @dev Set `liquidityCap`, Only allowed by the Pool Delegate or the admin.
+        @dev Set `liquidityCap`. Only the Pool Delegate or a Pool Admin can call this function.
         @param newLiquidityCap New liquidityCap value
     */
     function setLiquidityCap(uint256 newLiquidityCap) external {
@@ -284,7 +286,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Set the lockup period. Only Pool Delegate can call this function.
+        @dev Set the lockup period. Only the Pool Delegate can call this function.
         @param newLockupPeriod New lockup period used to restrict the withdrawals.
      */
     function setLockupPeriod(uint256 newLockupPeriod) external {
@@ -295,7 +297,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Update staking fee. Only Pool Delegate can call this function.
+        @dev Update staking fee. Only the Pool Delegate can call this function.
         @param newStakingFee New staking fee.
     */
     function setStakingFee(uint256 newStakingFee) external {
@@ -306,7 +308,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Update user status on Pool allowlist. Only Pool Delegate can call this function.
+        @dev Update user status on Pool allowlist. Only the Pool Delegate can call this function.
         @param user   The address to set status for.
         @param status The status of user on allowlist.
     */
@@ -317,7 +319,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Update user status on StakeLocker allowlist. Only Pool Delegate can call this function.
+        @dev Update user status on StakeLocker allowlist. Only the Pool Delegate can call this function.
         @param user   The address to set status for.
         @param status The status of user on allowlist.
     */
@@ -327,7 +329,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Set admin. Can only be called by the Pool Delegate.
+        @dev Set admin. Only the Pool Delegate can call this function.
         @param newAdmin new admin address.
         @param allowed Status of an admin.
     */
@@ -337,7 +339,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Set public pool access. Only Pool Delegate can call this function.
+        @dev Set public pool access. Only the Pool Delegate can call this function.
         @param open Public pool access status.
     */
     function setOpenToPublic(bool open) external {
@@ -440,7 +442,7 @@ contract Pool is PoolFDT {
     /**************************/
 
     /**
-        @dev Transfer any locked funds to the governor.
+        @dev Transfer any locked funds to the Governor. Only the Governor can call this function.
         @param token Address of the token to reclaim.
     */
     function reclaimERC20(address token) external {
@@ -564,7 +566,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Utility to return if msg.sender is the Pool Delegate.
+        @dev Checks that msg.sender is the Pool Delegate.
     */
     function _isValidDelegate() internal view {
         require(msg.sender == poolDelegate, "Pool:INVALID_DELEGATE");
@@ -594,7 +596,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Function to determine if msg.sender is Pool Delegate or a Pool Admin.
+        @dev Checks that msg.sender is the Pool Delegate or a Pool Admin.
     */
     function _isValidDelegateOrAdmin() internal {
         require(msg.sender == poolDelegate || admins[msg.sender], "Pool:UNAUTHORIZED");
@@ -607,6 +609,9 @@ contract Pool is PoolFDT {
         require(!_globals(superFactory).protocolPaused(), "Pool:PROTOCOL_PAUSED");
     }
 
+    /**
+        @dev Checks that msg.sender is the Pool Delegate and protocol is not in a paused state.
+    */
     function _isValidDelegateAndProtocolNotPaused() internal {
         _isValidDelegate();
         _whenProtocolNotPaused();

--- a/contracts/PoolFactory.sol
+++ b/contracts/PoolFactory.sol
@@ -120,7 +120,7 @@ contract PoolFactory is Pausable {
     }
 
     /**
-        @dev Triggers paused state. Halts functionality for certain functions. Only Governor can call this function.
+        @dev Triggers paused state. Halts functionality for certain functions. Only Governor or Pool Factory Admins can call this function.
     */
     function pause() external {
         _isValidGovernorOrAdmin();
@@ -128,7 +128,7 @@ contract PoolFactory is Pausable {
     }
 
     /**
-        @dev Triggers unpaused state. Returns functionality for certain functions. Only Governor can call this function.
+        @dev Triggers unpaused state. Returns functionality for certain functions. Only Governor or Pool Factory Admins can call this function.
     */
     function unpause() external {
         _isValidGovernorOrAdmin();
@@ -136,21 +136,21 @@ contract PoolFactory is Pausable {
     }
 
     /**
-        @dev Function to determine if msg.sender is eligible to trigger pause/unpause.
+        @dev Function to determine if msg.sender is Governor.
     */
     function _isValidGovernor() internal view {
         require(msg.sender == globals.governor(), "PF:INVALID_GOVERNOR");
     }
 
     /**
-        @dev Function to determine if msg.sender is eligible to trigger pause/unpause.
+        @dev Function to determine if msg.sender is Governor or a Pool Factory Admin.
     */
     function _isValidGovernorOrAdmin() internal {
         require(msg.sender == globals.governor() || admins[msg.sender], "PF:UNAUTHORIZED");
     }
 
     /**
-        @dev Function to determine if msg.sender is eligible to trigger pause/unpause.
+        @dev Function to determine if protocol is paused/unpaused.
     */
     function _whenProtocolNotPaused() internal {
         require(!globals.protocolPaused(), "PF:PROTOCOL_PAUSED");

--- a/contracts/PoolFactory.sol
+++ b/contracts/PoolFactory.sol
@@ -37,7 +37,7 @@ contract PoolFactory is Pausable {
     }
 
     /**
-        @dev Update the MapleGlobals contract
+        @dev Update the MapleGlobals contract. Only the Governor can call this function.
         @param newGlobals Address of new MapleGlobals contract
     */
     function setGlobals(address newGlobals) external {
@@ -110,7 +110,7 @@ contract PoolFactory is Pausable {
     }
 
     /**
-        @dev Set admin.
+        @dev Set admin. Only the Governor can call this function.
         @param newAdmin New admin address
         @param allowed  Status of an admin
     */
@@ -120,7 +120,7 @@ contract PoolFactory is Pausable {
     }
 
     /**
-        @dev Triggers paused state. Halts functionality for certain functions. Only Governor or Pool Factory Admins can call this function.
+        @dev Triggers paused state. Halts functionality for certain functions. Only the Governor or a Pool Factory Admin can call this function.
     */
     function pause() external {
         _isValidGovernorOrAdmin();
@@ -128,7 +128,7 @@ contract PoolFactory is Pausable {
     }
 
     /**
-        @dev Triggers unpaused state. Returns functionality for certain functions. Only Governor or Pool Factory Admins can call this function.
+        @dev Triggers unpaused state. Returns functionality for certain functions. Only the Governor or a Pool Factory Admin can call this function.
     */
     function unpause() external {
         _isValidGovernorOrAdmin();
@@ -136,14 +136,14 @@ contract PoolFactory is Pausable {
     }
 
     /**
-        @dev Function to determine if msg.sender is Governor.
+        @dev Checks that msg.sender is the Governor.
     */
     function _isValidGovernor() internal view {
         require(msg.sender == globals.governor(), "PF:INVALID_GOVERNOR");
     }
 
     /**
-        @dev Function to determine if msg.sender is Governor or a Pool Factory Admin.
+        @dev Checks that msg.sender is the Governor or a Pool Factory Admin.
     */
     function _isValidGovernorOrAdmin() internal {
         require(msg.sender == globals.governor() || admins[msg.sender], "PF:UNAUTHORIZED");

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -101,7 +101,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Set StakerLocker public access. Only PoolDelegate can call this function.
+        @dev Set StakerLocker public access. Only Pool Delegate can call this function.
     */
     function openStakeLockerToPublic() external {
         _whenProtocolNotPaused();
@@ -123,7 +123,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Transfers amt of stakeAsset to dst.
+        @dev Transfers amt of stakeAsset to dst. Only Pool can call this function.
         @param dst Desintation to transfer stakeAsset to
         @param amt Amount of stakeAsset to transfer
     */
@@ -293,14 +293,14 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Function to determine if msg.sender is eligible to trigger pause/unpause.
+        @dev Function to determine if msg.sender is Pool Delegate or a Pool Admin.
     */
     function _isValidAdminOrPoolDelegate() internal view {
         require(msg.sender == IPool(pool).poolDelegate() || IPool(pool).admins(msg.sender), "StakeLocker:UNAUTHORIZED");
     }
 
     /**
-        @dev Function to determine if msg.sender is eligible to trigger pause/unpause.
+        @dev Function to determine if msg.sender is Pool Delegate.
     */
     function _isValidPoolDelegate() internal view {
         require(msg.sender == IPool(pool).poolDelegate(), "StakeLocker:UNAUTHORIZED");

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -58,8 +58,8 @@ contract StakeLocker is StakeLockerFDT, Pausable {
 
     /**
         @dev canUnstake enables unstaking in the following conditions:
-        1. User is not Pool Delegate and the Pool is in Finalized state.
-        2. The Pool is in Initialized or Deactivated state.
+               1. User is not Pool Delegate and the Pool is in Finalized state.
+               2. The Pool is in Initialized or Deactivated state.
     */
     modifier canUnstake() {
         require(
@@ -71,7 +71,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Modifier to check if msg.sender is Governor.
+        @dev Checks that msg.sender is the Governor.
     */
     modifier isGovernor() {
         require(msg.sender == _globals().governor(), "StakeLocker:MSG_SENDER_NOT_GOVERNOR");
@@ -79,7 +79,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Modifier to check if msg.sender is Pool.
+        @dev Checks that msg.sender is the Pool.
     */
     modifier isPool() {
         require(msg.sender == pool, "StakeLocker:MSG_SENDER_NOT_POOL");
@@ -91,7 +91,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     /**********************/
 
     /**
-        @dev Update user status on the allowlist. Only Pool can call this.
+        @dev Update user status on the allowlist. Only the Pool can call this function.
         @param user   The address to set status for
         @param status The status of user on allowlist
     */
@@ -101,7 +101,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Set StakerLocker public access. Only Pool Delegate can call this function.
+        @dev Set StakerLocker public access. Only the Pool Delegate can call this function.
     */
     function openStakeLockerToPublic() external {
         _whenProtocolNotPaused();
@@ -111,7 +111,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Set the lockup period. Only Pool Delegate can call this function.
+        @dev Set the lockup period. Only the Pool Delegate can call this function.
         @param newLockupPeriod New lockup period used to restrict unstaking.
      */
     function setLockupPeriod(uint256 newLockupPeriod) external {
@@ -123,7 +123,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Transfers amt of stakeAsset to dst. Only Pool can call this function.
+        @dev Transfers amt of stakeAsset to dst. Only the Pool can call this function.
         @param dst Desintation to transfer stakeAsset to
         @param amt Amount of stakeAsset to transfer
     */
@@ -132,7 +132,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Updates loss accounting for FDTs after BPTs have been burned. Only Pool can call this function.
+        @dev Updates loss accounting for FDTs after BPTs have been burned. Only the Pool can call this function.
         @param bptsBurned Amount of BPTs that have been burned
     */
     function updateLosses(uint256 bptsBurned) isPool external {
@@ -219,7 +219,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         emit BalanceUpdated(address(this), address(stakeAsset), stakeAsset.balanceOf(address(this)));
     }
 
-     /**
+    /**
         @dev Withdraws all available FDT interest earned for a token holder.
     */
     function withdrawFunds() public override {
@@ -256,7 +256,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     /***********************/
 
     /**
-        @dev Triggers paused state. Halts functionality for certain functions.
+        @dev Triggers paused state. Halts functionality for certain functions. Only the Pool Delegate or a Pool Admin can call this function.
     */
     function pause() external {
         _isValidAdminOrPoolDelegate();
@@ -264,7 +264,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Triggers unpaused state. Returns functionality for certain functions.
+        @dev Triggers unpaused state. Returns functionality for certain functions. Only the Pool Delegate or a Pool Admin can call this function.
     */
     function unpause() external {
         _isValidAdminOrPoolDelegate();
@@ -276,7 +276,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     /************************/
 
     /**
-        @dev View function to indicate if cooldown period has passed for msg.sender and if they are in the unstake window
+        @dev View function to indicate if cooldown period has passed for msg.sender and if they are in the unstake window.
     */
     function isUnstakeAllowed(address from) public view returns (bool) {
         IGlobals globals = _globals();
@@ -293,14 +293,14 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     }
 
     /**
-        @dev Function to determine if msg.sender is Pool Delegate or a Pool Admin.
+        @dev Checks that msg.sender is the Pool Delegate or a Pool Admin.
     */
     function _isValidAdminOrPoolDelegate() internal view {
         require(msg.sender == IPool(pool).poolDelegate() || IPool(pool).admins(msg.sender), "StakeLocker:UNAUTHORIZED");
     }
 
     /**
-        @dev Function to determine if msg.sender is Pool Delegate.
+        @dev Checks that msg.sender is the Pool Delegate.
     */
     function _isValidPoolDelegate() internal view {
         require(msg.sender == IPool(pool).poolDelegate(), "StakeLocker:UNAUTHORIZED");

--- a/contracts/library/LoanLib.sol
+++ b/contracts/library/LoanLib.sol
@@ -55,7 +55,7 @@ library LoanLib {
     }
 
     /**
-        @dev Liquidate a Borrower's collateral via Uniswap when a default is triggered.
+        @dev Liquidate a Borrower's collateral via Uniswap when a default is triggered. Only the Loan can call this function.
         @param collateralAsset   IERC20 of the collateralAsset
         @param liquidityAsset         Address of liquidityAsset
         @param superFactory      Factory that instantiated Loan
@@ -122,7 +122,7 @@ library LoanLib {
     /**********************************/
 
     /**
-        @dev Transfer any locked funds to the governor.
+        @dev Transfer any locked funds to the Governor. Only the Governor can call this function.
         @param token Address of the token that need to reclaimed.
         @param liquidityAsset Address of loan asset that is supported by the loan in other words denominated currency in which it taking funds.
         @param globals Instance of the `MapleGlobals` contract.

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -31,7 +31,7 @@ library PoolLib {
     /***************************************/
 
     /** 
-        @dev Conducts sanity checks for Pools in the constructor
+        @dev Conducts sanity checks for Pools in the constructor.
         @param globals        Address of MapleGlobals
         @param liquidityAsset Asset used by Pool for liquidity to fund loans
         @param stakeAsset     Asset escrowed in StakeLocker
@@ -221,7 +221,7 @@ library PoolLib {
     }
 
     /**
-        @dev View function to indicate if msg.sender is within their withdraw window
+        @dev View function to indicate if msg.sender is within their withdraw window.
     */
     function isWithdrawAllowed(uint256 withdrawCooldown, IGlobals globals) public view returns (bool) {
         return block.timestamp - (withdrawCooldown + globals.lpCooldownPeriod()) <= globals.lpWithdrawWindow();
@@ -279,7 +279,7 @@ library PoolLib {
     /**********************************/
 
     /**
-        @dev Transfer any locked funds to the governor.
+        @dev Transfer any locked funds to the governor. Only the Governor can call this function.
         @param token Address of the token that need to reclaimed.
         @param liquidityAsset Address of liquidity asset that is supported by the pool.
         @param globals Instance of the `MapleGlobals` contract.

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -45,7 +45,7 @@ contract ChainlinkOracle is Ownable {
 
 
     /**
-        @dev Updates aggregator address.
+        @dev Updates aggregator address. Only the contract Owner can call this fucntion.
         @param aggregator Address of chainlink aggregator
     */
     function changeAggregator(address aggregator) external onlyOwner {
@@ -70,7 +70,8 @@ contract ChainlinkOracle is Ownable {
     }
 
     /**
-        @dev Set a manual price. NOTE: this can only be used if manualOverride == true
+        @dev Set a manual price.  Only the contract Owner can call this fucntion.
+             NOTE: this can only be used if manualOverride == true.
         @param _price Price to set
     */
     function setManualPrice(int256 _price) public onlyOwner {
@@ -79,7 +80,7 @@ contract ChainlinkOracle is Ownable {
     }
 
     /**
-        @dev Set manual override, allowing for manual price setting.
+        @dev Set manual override, allowing for manual price setting. Only the contract Owner can call this fucntion.
         @param _override Whether to use the manual override price or not
     */
     function setManualOverride(bool _override) public onlyOwner {

--- a/contracts/oracles/UsdOracle.sol
+++ b/contracts/oracles/UsdOracle.sol
@@ -8,7 +8,7 @@ contract UsdOracle {
 
     /**
         @dev Returns the constant USD price.
-     */
+    */
     function getLatestPrice() public pure returns (int256) {
         return USD_PRICE;
     }

--- a/contracts/token/BasicFDT.sol
+++ b/contracts/token/BasicFDT.sol
@@ -37,7 +37,7 @@ abstract contract BasicFDT is IFDT, ERC20 {
                 in a distribution can be less than 1 (base unit).
             We can actually keep track of the undistributed ether in a distribution
                 and try to distribute it in the next distribution.
-     */
+    */
     function _distributeFunds(uint256 value) internal {
         require(totalSupply() > 0, "FDT:SUPPLY_EQ_ZERO");
 
@@ -49,7 +49,7 @@ abstract contract BasicFDT is IFDT, ERC20 {
     }
 
     /**
-        @dev Prepares funds withdrawal
+        @dev Prepares funds withdrawal.
         @dev It emits a `FundsWithdrawn` event if the amount of withdrawn ether is greater than 0.
     */
     function _prepareWithdraw() internal returns (uint256) {
@@ -150,13 +150,13 @@ abstract contract BasicFDT is IFDT, ERC20 {
     }
 
     /**
-        @dev Withdraws all available funds for a token holder
+        @dev Withdraws all available funds for a token holder.
     */
     function withdrawFunds() public virtual override {}
 
     /**
         @dev Updates the current funds token balance
-        and returns the difference of new and previous funds token balances
+             and returns the difference of new and previous funds token balances.
         @return A int256 representing the difference of the new and previous funds token balance
     */
     function _updateFundsTokenBalance() internal virtual returns (int256) {}

--- a/contracts/token/ExtendedFDT.sol
+++ b/contracts/token/ExtendedFDT.sol
@@ -19,10 +19,10 @@ abstract contract ExtendedFDT is BasicFDT {
     event LossesCorrectionUpdated(address account, int256 lossesCorrection);
 
     /**
-        @dev This event emits when new losses are distributed
+        @dev This event emits when new losses are distributed.
         @param by                The address of the sender who distributed losses
         @param lossesDistributed The amount of losses received for distribution
-     */
+    */
     event LossesDistributed(address indexed by, uint256 lossesDistributed);
 
     /**
@@ -30,7 +30,7 @@ abstract contract ExtendedFDT is BasicFDT {
         @param by                    The address of the receiver of losses
         @param lossesRecognized      The amount of losses that were recognized
         @param totalLossesRecognized The total amount of losses that were recognized
-     */
+    */
     event LossesRecognized(address indexed by, uint256 lossesRecognized, uint256 totalLossesRecognized);
 
     constructor(string memory name, string memory symbol) BasicFDT(name, symbol) public { }
@@ -38,14 +38,14 @@ abstract contract ExtendedFDT is BasicFDT {
     /**
         @dev Distributes losses to token holders.
         @dev It reverts if the total supply of tokens is 0.
-        It emits the `LossesDistributed` event if the amount of received losses is greater than 0.
-        About undistributed losses:
-            In each distribution, there is a small amount of losses which does not get distributed,
-            which is `(value * pointsMultiplier) % totalSupply()`.
-        With a well-chosen `pointsMultiplier`, the amount losses that are not getting distributed
-            in a distribution can be less than 1 (base unit).
-        We can actually keep track of the undistributed losses in a distribution
-            and try to distribute it in the next distribution
+             It emits the `LossesDistributed` event if the amount of received losses is greater than 0.
+             About undistributed losses:
+                In each distribution, there is a small amount of losses which does not get distributed,
+                which is `(value * pointsMultiplier) % totalSupply()`.
+             With a well-chosen `pointsMultiplier`, the amount losses that are not getting distributed
+                in a distribution can be less than 1 (base unit).
+             We can actually keep track of the undistributed losses in a distribution
+                and try to distribute it in the next distribution
     */
     function _distributeLosses(uint256 value) internal {
         require(totalSupply() > 0, "FDT:SUPPLY_EQ_ZERO");
@@ -58,7 +58,7 @@ abstract contract ExtendedFDT is BasicFDT {
     }
 
     /**
-        @dev Prepares losses withdrawal
+        @dev Prepares losses withdrawal.
         @dev It emits a `LossesWithdrawn` event if the amount of withdrawn losses is greater than 0.
     */
     function _prepareLossesWithdraw() internal returns (uint256) {

--- a/contracts/token/FDT.sol
+++ b/contracts/token/FDT.sol
@@ -22,7 +22,7 @@ abstract contract FDT is BasicFDT {
     }
 
     /**
-        @dev Withdraws all available funds for a token holder
+        @dev Withdraws all available funds for a token holder.
     */
     function withdrawFunds() public virtual override {
         uint256 withdrawableFunds = _prepareWithdraw();
@@ -36,7 +36,7 @@ abstract contract FDT is BasicFDT {
 
     /**
         @dev Updates the current funds token balance
-        and returns the difference of new and previous funds token balances
+             and returns the difference of new and previous funds token balances.
         @return A int256 representing the difference of the new and previous funds token balance
     */
     function _updateFundsTokenBalance() internal virtual override returns (int256) {

--- a/contracts/token/IFDT.sol
+++ b/contracts/token/IFDT.sol
@@ -15,7 +15,7 @@ interface IFDT {
     function withdrawFunds() external;
 
     /**
-        @dev This event emits when new funds are distributed
+        @dev This event emits when new funds are distributed.
         @param by the address of the sender who distributed funds
         @param fundsDistributed the amount of funds received for distribution
     */

--- a/contracts/token/PoolFDT.sol
+++ b/contracts/token/PoolFDT.sol
@@ -19,7 +19,7 @@ abstract contract PoolFDT is ExtendedFDT {
     constructor(string memory name, string memory symbol) ExtendedFDT(name, symbol) public { }
 
     /**
-        @dev Realizes losses incurred to LPs
+        @dev Realizes losses incurred to LPs.
     */
     function recognizeLosses() internal override returns (uint256 losses) {
         losses = _prepareLossesWithdraw();

--- a/contracts/token/StakeLockerFDT.sol
+++ b/contracts/token/StakeLockerFDT.sol
@@ -21,7 +21,7 @@ abstract contract StakeLockerFDT is ExtendedFDT {
     }
 
     /**
-        @dev Updates loss accounting for msg.sender, recognizing losses
+        @dev Updates loss accounting for msg.sender, recognizing losses.
         @return losses - amount to be subtracted from given withdraw amount
     */
     function recognizeLosses() internal override returns (uint256 losses) {


### PR DESCRIPTION
# Description

Rectify NatSpec-related issues raised by C4 and and normalize related descriptions code-wide.

Clubhouse: https://app.clubhouse.io/maplefinance/story/2032/maple-core-natspec-updates-from-c4-audit

# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [X] Has all documentation been updated?

# Changelog

- C4 audit Natspec issues 34, 42, 46, 47, 54, 55, 56, 57, 58, 59, 60, 61, 64, 70, and 71 (see commit description for links)
- Standardized "Only X [and Y] can call this function"
- Standardized "a" and "the" grammar, to explicitly indicate if there is one or many of that type that can access
- Standardized "Checks that msg.sender is the X [or Y]" for access control require helpers and modifiers
- Standardized role capitalization (i.e. Owner, Pool Delegate) in access control comments
- Normalized indentation for @dev
- Ensured all access controls are indicated, including those inherited from downstream
- Ensured period at the end of all @dev sentences
- Fixed erroneous comment indentation (lead to broken collapsing)
- Fixed a bad function indent (lead to broken collapsing)

## Function Signature Changes

## Features 

## Events

