### PR TITLE
chore: Error Messages C4 fixes and normalization (SC-2036)

### DIFF
--- a/contracts/CollateralLocker.sol
+++ b/contracts/CollateralLocker.sol
@@ -20,7 +20,7 @@ contract CollateralLocker {
         @dev Checks that msg.sender is the Loan.
     */
     modifier isLoan() {
-        require(msg.sender == loan, "CL:NOT_LOAN");
+        require(msg.sender == loan, "CL:NOT_L");
         _;
     }
 

--- a/contracts/CollateralLocker.sol
+++ b/contracts/CollateralLocker.sol
@@ -20,7 +20,7 @@ contract CollateralLocker {
         @dev Checks that msg.sender is the Loan.
     */
     modifier isLoan() {
-        require(msg.sender == loan, "CollateralLocker:MSG_SENDER_NOT_LOAN");
+        require(msg.sender == loan, "CL:NOT_LOAN");
         _;
     }
 

--- a/contracts/DebtLocker.sol
+++ b/contracts/DebtLocker.sol
@@ -29,7 +29,7 @@ contract DebtLocker {
         @dev Checks that msg.sender is the Pool.
     */
     modifier isPool() {
-        require(msg.sender == pool, "DL:NOT_POOL");
+        require(msg.sender == pool, "DL:NOT_P");
         _;
     }
 

--- a/contracts/DebtLocker.sol
+++ b/contracts/DebtLocker.sol
@@ -29,7 +29,7 @@ contract DebtLocker {
         @dev Checks that msg.sender is the Pool.
     */
     modifier isPool() {
-        require(msg.sender == pool, "DebtLocker:MSG_SENDER_NOT_POOL");
+        require(msg.sender == pool, "DL:NOT_POOL");
         _;
     }
 

--- a/contracts/FundingLocker.sol
+++ b/contracts/FundingLocker.sol
@@ -20,7 +20,7 @@ contract FundingLocker {
         @dev Checks that msg.sender is the Loan.
     */
     modifier isLoan() {
-        require(msg.sender == loan, "FL:NOT_LOAN");
+        require(msg.sender == loan, "FL:NOT_L");
         _;
     }
 

--- a/contracts/FundingLocker.sol
+++ b/contracts/FundingLocker.sol
@@ -20,7 +20,7 @@ contract FundingLocker {
         @dev Checks that msg.sender is the Loan.
     */
     modifier isLoan() {
-        require(msg.sender == loan, "FundingLocker:MSG_SENDER_NOT_LOAN");
+        require(msg.sender == loan, "FL:NOT_LOAN");
         _;
     }
 

--- a/contracts/LiquidityLocker.sol
+++ b/contracts/LiquidityLocker.sol
@@ -22,7 +22,7 @@ contract LiquidityLocker {
         @dev Checks that msg.sender is the Pool.
     */
     modifier isPool() {
-        require(msg.sender == pool, "LL:NOT_POOL");
+        require(msg.sender == pool, "LL:NOT_P");
         _;
     }
 
@@ -32,7 +32,7 @@ contract LiquidityLocker {
         @param amt Amount of liquidityAsset to transfer
     */
     function transfer(address dst, uint256 amt) external isPool {
-        require(dst != address(0), "LL:NULL_TRANSFER_DST");
+        require(dst != address(0), "LL:NULL_DST");
         liquidityAsset.safeTransfer(dst, amt);
     }
 

--- a/contracts/LiquidityLocker.sol
+++ b/contracts/LiquidityLocker.sol
@@ -22,7 +22,7 @@ contract LiquidityLocker {
         @dev Checks that msg.sender is the Pool.
     */
     modifier isPool() {
-        require(msg.sender == pool, "LiquidityLocker:MSG_SENDER_NOT_POOL");
+        require(msg.sender == pool, "LL:NOT_POOL");
         _;
     }
 
@@ -32,7 +32,7 @@ contract LiquidityLocker {
         @param amt Amount of liquidityAsset to transfer
     */
     function transfer(address dst, uint256 amt) external isPool {
-        require(dst != address(0), "LiquidityLocker:NULL_TRASNFER_DST");
+        require(dst != address(0), "LL:NULL_TRANSFER_DST");
         liquidityAsset.safeTransfer(dst, amt);
     }
 

--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -144,12 +144,12 @@ contract Loan is FDT, Pausable {
         IGlobals globals = _globals(msg.sender);
 
         // Perform validity cross-checks
-        require(globals.isValidLiquidityAsset(_liquidityAsset),   "Loan:INVALID_LIQUIDITY_ASSET");
-        require(globals.isValidCollateralAsset(_collateralAsset), "Loan:INVALID_COLLATERAL_ASSET");
+        require(globals.isValidLiquidityAsset(_liquidityAsset),   "L:INVALID_LIQ_ASSET");
+        require(globals.isValidCollateralAsset(_collateralAsset), "L:INVALID_COLLATERAL_ASSET");
 
-        require(specs[2] != uint256(0),               "Loan:PID_EQ_ZERO");
-        require(specs[1].mod(specs[2]) == uint256(0), "Loan:INVALID_TERM_DAYS");
-        require(specs[3] > uint256(0),                "Loan:REQUEST_AMT_EQ_ZERO");
+        require(specs[2] != uint256(0),               "L:PID_EQ_ZERO");
+        require(specs[1].mod(specs[2]) == uint256(0), "L:INVALID_TERM_DAYS");
+        require(specs[3] > uint256(0),                "L:REQUEST_AMT_EQ_ZERO");
 
         borrower        = _borrower;
         liquidityAsset  = IERC20(_liquidityAsset);
@@ -197,8 +197,8 @@ contract Loan is FDT, Pausable {
 
         IFundingLocker _fundingLocker = IFundingLocker(fundingLocker);
 
-        require(amt >= requestAmount,              "Loan:AMT_LT_REQUEST_AMT");
-        require(amt <= _getFundingLockerBalance(), "Loan:AMT_GT_FUNDED_AMT");
+        require(amt >= requestAmount,              "L:AMT_LT_REQUEST_AMT");
+        require(amt <= _getFundingLockerBalance(), "L:AMT_GT_FUNDED_AMT");
 
         // Update accounting variables for Loan
         principalOwed  = amt;
@@ -363,7 +363,7 @@ contract Loan is FDT, Pausable {
     function triggerDefault() external {
         _whenProtocolNotPaused();
         _isValidState(State.Active);
-        require(LoanLib.canTriggerDefault(nextPaymentDue, defaultGracePeriod, superFactory, balanceOf(msg.sender), totalSupply()), "Loan:FAILED_TO_LIQUIDATE");
+        require(LoanLib.canTriggerDefault(nextPaymentDue, defaultGracePeriod, superFactory, balanceOf(msg.sender), totalSupply()), "L:FAILED_TO_LIQUIDATE");
 
         // Pull collateralAsset from CollateralLocker, swap to liquidityAsset, and hold custody of resulting liquidityAsset in Loan
         (amountLiquidated, amountRecovered) = LoanLib.liquidateCollateral(collateralAsset, address(liquidityAsset), superFactory, collateralLocker);
@@ -512,14 +512,14 @@ contract Loan is FDT, Pausable {
         @dev Function to block functionality of functions when protocol is in a paused state.
     */
     function _whenProtocolNotPaused() internal {
-        require(!_globals(superFactory).protocolPaused(), "Loan:PROTOCOL_PAUSED");
+        require(!_globals(superFactory).protocolPaused(), "L:PROTOCOL_PAUSED");
     }
 
     /**
         @dev Checks that msg.sender is the Loan Borrower or a Loan Admin.
     */
     function _isValidBorrowerOrAdmin() internal {
-        require(msg.sender == borrower || admins[msg.sender], "Pool:UNAUTHORIZED");
+        require(msg.sender == borrower || admins[msg.sender], "L:NOT_BORROWER_OR_ADMIN");
     }
 
     /**
@@ -555,14 +555,14 @@ contract Loan is FDT, Pausable {
         @param _state Enum of desired Loan state
     */
     function _isValidState(State _state) internal view {
-        require(loanState == _state, "Loan:INVALID_STATE");
+        require(loanState == _state, "L:INVALID_STATE");
     }
 
     /**
         @dev Checks that msg.sender is the Loan Borrower.
     */
     function _isValidBorrower() internal view {
-        require(msg.sender == borrower, "Loan:INVALID_BORROWER");
+        require(msg.sender == borrower, "L:NOT_BORROWER");
     }
 
     /**
@@ -574,7 +574,7 @@ contract Loan is FDT, Pausable {
         require(
             _globals(superFactory).isValidPoolFactory(poolFactory) &&
             IPoolFactory(poolFactory).isPool(pool),
-            "Loan:INVALID_LENDER"
+            "L:INVALID_LENDER"
         );
     }
 
@@ -582,7 +582,7 @@ contract Loan is FDT, Pausable {
         @dev Utility to ensure currently within the funding period.
     */
     function _isWithinFundingPeriod() internal view {
-        require(block.timestamp <= createdAt.add(fundingPeriod), "Loan:PAST_FUNDING_PERIOD");
+        require(block.timestamp <= createdAt.add(fundingPeriod), "L:PAST_FUNDING_PERIOD");
     }
 
     /**

--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -145,11 +145,11 @@ contract Loan is FDT, Pausable {
 
         // Perform validity cross-checks
         require(globals.isValidLiquidityAsset(_liquidityAsset),   "L:INVALID_LIQ_ASSET");
-        require(globals.isValidCollateralAsset(_collateralAsset), "L:INVALID_COLLATERAL_ASSET");
+        require(globals.isValidCollateralAsset(_collateralAsset), "L:INVALID_COL_ASSET");
 
-        require(specs[2] != uint256(0),               "L:PID_EQ_ZERO");
+        require(specs[2] != uint256(0),               "L:ZERO_PID");
         require(specs[1].mod(specs[2]) == uint256(0), "L:INVALID_TERM_DAYS");
-        require(specs[3] > uint256(0),                "L:REQUEST_AMT_EQ_ZERO");
+        require(specs[3] > uint256(0),                "L:ZERO_REQUEST_AMT");
 
         borrower        = _borrower;
         liquidityAsset  = IERC20(_liquidityAsset);
@@ -363,7 +363,7 @@ contract Loan is FDT, Pausable {
     function triggerDefault() external {
         _whenProtocolNotPaused();
         _isValidState(State.Active);
-        require(LoanLib.canTriggerDefault(nextPaymentDue, defaultGracePeriod, superFactory, balanceOf(msg.sender), totalSupply()), "L:FAILED_TO_LIQUIDATE");
+        require(LoanLib.canTriggerDefault(nextPaymentDue, defaultGracePeriod, superFactory, balanceOf(msg.sender), totalSupply()), "L:FAILED_TO_LIQ");
 
         // Pull collateralAsset from CollateralLocker, swap to liquidityAsset, and hold custody of resulting liquidityAsset in Loan
         (amountLiquidated, amountRecovered) = LoanLib.liquidateCollateral(collateralAsset, address(liquidityAsset), superFactory, collateralLocker);
@@ -512,7 +512,7 @@ contract Loan is FDT, Pausable {
         @dev Function to block functionality of functions when protocol is in a paused state.
     */
     function _whenProtocolNotPaused() internal {
-        require(!_globals(superFactory).protocolPaused(), "L:PROTOCOL_PAUSED");
+        require(!_globals(superFactory).protocolPaused(), "L:PROTO_PAUSED");
     }
 
     /**

--- a/contracts/LoanFactory.sol
+++ b/contracts/LoanFactory.sol
@@ -151,20 +151,20 @@ contract LoanFactory is Pausable {
         @dev Checks that msg.sender is the Governor.
     */
     function _isValidGovernor() internal view {
-        require(msg.sender == globals.governor(), "PoolFactory:INVALID_GOVERNOR");
+        require(msg.sender == globals.governor(), "LF:INVALID_GOVERNOR");
     }
 
     /**
         @dev Checks that msg.sender is the Governor or a Loan Factory Admin.
     */
     function _isValidGovernorOrAdmin() internal {
-        require(msg.sender == globals.governor() || admins[msg.sender], "PoolFactory:UNAUTHORIZED");
+        require(msg.sender == globals.governor() || admins[msg.sender], "LF:UNAUTHORIZED");
     }
 
     /**
         @dev Function to determine if protocol is paused/unpaused.
     */
     function _whenProtocolNotPaused() internal {
-        require(!globals.protocolPaused(), "PoolFactory:PROTOCOL_PAUSED");
+        require(!globals.protocolPaused(), "LF:PROTOCOL_PAUSED");
     }
 }

--- a/contracts/LoanFactory.sol
+++ b/contracts/LoanFactory.sol
@@ -65,11 +65,11 @@ contract LoanFactory is Pausable {
                 specs[2] = paymentIntervalDays
                 specs[3] = requestAmount
                 specs[4] = collateralRatio
-        @param  calcs The calculators used for the loan.
-                calcs[0] = repaymentCalc
-                calcs[1] = lateFeeCalc
-                calcs[2] = premiumCalc
-        @return Address of the instantiated Loan.
+        @param  calcs           The calculators used for the loan.
+                                    calcs[0] = repaymentCalc
+                                    calcs[1] = lateFeeCalc
+                                    calcs[2] = premiumCalc
+        @return loanAddress     Address of the instantiated Loan.
     */
     function createLoan(
         address liquidityAsset,
@@ -78,17 +78,17 @@ contract LoanFactory is Pausable {
         address clFactory,
         uint256[5] memory specs,
         address[3] memory calcs
-    ) external whenNotPaused returns (address) {
+    ) external whenNotPaused returns (address loanAddress) {
         _whenProtocolNotPaused();
         IGlobals _globals = globals;
 
         // Validity checks
-        require(_globals.isValidSubFactory(address(this), flFactory, FL_FACTORY), "LF:INVALID_FL_FACTORY");
-        require(_globals.isValidSubFactory(address(this), clFactory, CL_FACTORY), "LF:INVALID_CL_FACTORY");
+        require(_globals.isValidSubFactory(address(this), flFactory, FL_FACTORY), "LF:INVALID_FLF");
+        require(_globals.isValidSubFactory(address(this), clFactory, CL_FACTORY), "LF:INVALID_CLF");
 
-        require(_globals.isValidCalc(calcs[0], INTEREST_CALC_TYPE), "LF:INVALID_INTEREST_CALC");
-        require(_globals.isValidCalc(calcs[1],  LATEFEE_CALC_TYPE), "LF:INVALID_LATE_FEE_CALC");
-        require(_globals.isValidCalc(calcs[2],  PREMIUM_CALC_TYPE), "LF:INVALID_PREMIUM_CALC");
+        require(_globals.isValidCalc(calcs[0], INTEREST_CALC_TYPE), "LF:INVALID_INT_C");
+        require(_globals.isValidCalc(calcs[1],  LATEFEE_CALC_TYPE), "LF:INVALID_LATE_FEE_C");
+        require(_globals.isValidCalc(calcs[2],  PREMIUM_CALC_TYPE), "LF:INVALID_PREM_C");
 
         // Deploy new Loan
         Loan loan = new Loan(
@@ -102,12 +102,13 @@ contract LoanFactory is Pausable {
         );
 
         // Update LoanFactory identification mappings
-        loans[loansCreated]   = address(loan);
-        isLoan[address(loan)] = true;
+        loanAddress = address(loan);
+        loans[loansCreated]   = loanAddress;
+        isLoan[loanAddress] = true;
         loansCreated++;
 
         emit LoanCreated(
-            address(loan),
+            loanAddress,
             msg.sender,
             liquidityAsset,
             collateralAsset,
@@ -118,7 +119,6 @@ contract LoanFactory is Pausable {
             loan.name(),
             loan.symbol()
         );
-        return address(loan);
     }
 
     /**
@@ -165,6 +165,6 @@ contract LoanFactory is Pausable {
         @dev Function to determine if protocol is paused/unpaused.
     */
     function _whenProtocolNotPaused() internal {
-        require(!globals.protocolPaused(), "LF:PROTOCOL_PAUSED");
+        require(!globals.protocolPaused(), "LF:PROTO_PAUSED");
     }
 }

--- a/contracts/LoanFactory.sol
+++ b/contracts/LoanFactory.sol
@@ -151,14 +151,14 @@ contract LoanFactory is Pausable {
         @dev Checks that msg.sender is the Governor.
     */
     function _isValidGovernor() internal view {
-        require(msg.sender == globals.governor(), "LF:INVALID_GOVERNOR");
+        require(msg.sender == globals.governor(), "LF:NOT_GOV");
     }
 
     /**
         @dev Checks that msg.sender is the Governor or a Loan Factory Admin.
     */
     function _isValidGovernorOrAdmin() internal {
-        require(msg.sender == globals.governor() || admins[msg.sender], "LF:UNAUTHORIZED");
+        require(msg.sender == globals.governor() || admins[msg.sender], "LF:NOT_GOV_OR_ADMIN");
     }
 
     /**

--- a/contracts/LoanFactory.sol
+++ b/contracts/LoanFactory.sol
@@ -102,8 +102,8 @@ contract LoanFactory is Pausable {
         );
 
         // Update LoanFactory identification mappings
-        loanAddress = address(loan);
-        loans[loansCreated]   = loanAddress;
+        loanAddress         = address(loan);
+        loans[loansCreated] = loanAddress;
         isLoan[loanAddress] = true;
         loansCreated++;
 

--- a/contracts/MapleGlobals.sol
+++ b/contracts/MapleGlobals.sol
@@ -71,7 +71,7 @@ contract MapleGlobals {
         @dev Checks that msg.sender is the Governor.
     */
     modifier isGovernor() {
-        require(msg.sender == governor, "MapleGlobals:MSG_SENDER_NOT_GOVERNOR");
+        require(msg.sender == governor, "MG:NOT_GOV");
         _;
     }
 
@@ -165,8 +165,8 @@ contract MapleGlobals {
       @param newAdmin New admin address
      */
     function setAdmin(address newAdmin) external {
-        require(msg.sender == governor && admin != address(0), "MapleGlobals:UNAUTHORIZED");
-        require(!protocolPaused, "MapleGlobals:PROCOTOL_PAUSED");
+        require(msg.sender == governor && admin != address(0), "MG:NOT_GOV_OR_ADMIN");
+        require(!protocolPaused, "MG:PROCOTOL_PAUSED");
         admin = newAdmin;
         emit AdminSet(newAdmin);
     }
@@ -201,7 +201,7 @@ contract MapleGlobals {
       @param pause Boolean flag to switch externally facing functionality in the protocol on/off
     */
     function setProtocolPause(bool pause) external {
-        require(msg.sender == admin, "MapleGlobals:UNAUTHORIZED");
+        require(msg.sender == admin, "MG:NOT_ADMIN");
         protocolPaused = pause;
         emit ProtocolPaused(pause);
     }
@@ -231,7 +231,7 @@ contract MapleGlobals {
         @param valid        The validity of subFactory within context of superFactory
     */
     function setValidSubFactory(address superFactory, address subFactory, bool valid) external isGovernor {
-        require(isValidLoanFactory[superFactory] || isValidPoolFactory[superFactory], "MapleGlobals:SUPER_FACTORY_NOT_VALID");
+        require(isValidLoanFactory[superFactory] || isValidPoolFactory[superFactory], "MG:SUPER_FACTORY_NOT_VALID");
         validSubFactories[superFactory][subFactory] = valid;
     }
 
@@ -297,7 +297,7 @@ contract MapleGlobals {
     */
     function setInvestorFee(uint256 _fee) external isGovernor {
         _checkPercentageRange(_fee);
-        require(_fee + treasuryFee <= 10_000, "MapleGlobals:INVALID_INVESTOR_FEE");
+        require(_fee + treasuryFee <= 10_000, "MG:INVALID_INVESTOR_FEE");
         investorFee = _fee;
         emit GlobalsParamSet("INVESTOR_FEE", _fee);
     }
@@ -309,7 +309,7 @@ contract MapleGlobals {
     */
     function setTreasuryFee(uint256 _fee) external isGovernor {
         _checkPercentageRange(_fee);
-        require(_fee + investorFee <= 10_000, "MapleGlobals:INVALID_TREASURY_FEE");
+        require(_fee + investorFee <= 10_000, "MG:INVALID_TREASURY_FEE");
         treasuryFee = _fee;
         emit GlobalsParamSet("TREASURY_FEE", _fee);
     }
@@ -320,7 +320,7 @@ contract MapleGlobals {
         @param _mapleTreasury New MapleTreasury address
     */
     function setMapleTreasury(address _mapleTreasury) external isGovernor {
-        require(_mapleTreasury != address(0), "MapleGlobals:ZERO_ADDRESS");
+        require(_mapleTreasury != address(0), "MG:ZERO_ADDRESS");
         mapleTreasury = _mapleTreasury;
         emit GlobalsAddressSet("MAPLE_TREASURY", _mapleTreasury);
     }
@@ -362,7 +362,7 @@ contract MapleGlobals {
         @param amt The new minimum swap out required
     */
     function setSwapOutRequired(uint256 amt) external isGovernor {
-        require(amt >= uint256(10_000), "MapleGlobals:SWAP_OUT_TOO_LOW");
+        require(amt >= uint256(10_000), "MG:SWAP_OUT_TOO_LOW");
         swapOutRequired = amt;
         emit GlobalsParamSet("SWAP_OUT_REQUIRED", amt);
     }
@@ -388,7 +388,7 @@ contract MapleGlobals {
         @param _pendingGovernor Address of new Governor
     */
     function setPendingGovernor(address _pendingGovernor) external isGovernor {
-        require(_pendingGovernor != address(0), "MapleGlobals:ZERO_ADDRESS_GOVERNOR");
+        require(_pendingGovernor != address(0), "MG:ZERO_ADDRESS_GOVERNOR");
         pendingGovernor = _pendingGovernor;
         emit PendingGovernorSet(_pendingGovernor);
     }
@@ -398,7 +398,7 @@ contract MapleGlobals {
         @dev It emits a `GovernorAccepted` event.
     */
     function acceptGovernor() external {
-        require(msg.sender == pendingGovernor, "MapleGlobals:NOT_PENDING_GOVERNOR");
+        require(msg.sender == pendingGovernor, "MG:NOT_PENDING_GOVERNOR");
         governor = pendingGovernor;
         pendingGovernor = address(0);
         emit GovernorAccepted(governor);
@@ -446,6 +446,6 @@ contract MapleGlobals {
     /************************/
 
     function _checkPercentageRange(uint256 percentage) internal {
-        require(percentage >= uint256(0) && percentage <= uint256(10_000), "MapleGlobals:PCT_BOUND_CHECK");
+        require(percentage >= uint256(0) && percentage <= uint256(10_000), "MG:PCT_BOUND_CHECK");
     }
 }

--- a/contracts/MapleGlobals.sol
+++ b/contracts/MapleGlobals.sol
@@ -166,7 +166,7 @@ contract MapleGlobals {
      */
     function setAdmin(address newAdmin) external {
         require(msg.sender == governor && admin != address(0), "MG:NOT_GOV_OR_ADMIN");
-        require(!protocolPaused, "MG:PROCOTOL_PAUSED");
+        require(!protocolPaused, "MG:PROTO_PAUSED");
         admin = newAdmin;
         emit AdminSet(newAdmin);
     }
@@ -231,7 +231,7 @@ contract MapleGlobals {
         @param valid        The validity of subFactory within context of superFactory
     */
     function setValidSubFactory(address superFactory, address subFactory, bool valid) external isGovernor {
-        require(isValidLoanFactory[superFactory] || isValidPoolFactory[superFactory], "MG:SUPER_FACTORY_NOT_VALID");
+        require(isValidLoanFactory[superFactory] || isValidPoolFactory[superFactory], "MG:INVALID_SUPER_F");
         validSubFactories[superFactory][subFactory] = valid;
     }
 
@@ -320,7 +320,7 @@ contract MapleGlobals {
         @param _mapleTreasury New MapleTreasury address
     */
     function setMapleTreasury(address _mapleTreasury) external isGovernor {
-        require(_mapleTreasury != address(0), "MG:ZERO_ADDRESS");
+        require(_mapleTreasury != address(0), "MG:ZERO_ADDR");
         mapleTreasury = _mapleTreasury;
         emit GlobalsAddressSet("MAPLE_TREASURY", _mapleTreasury);
     }
@@ -388,7 +388,7 @@ contract MapleGlobals {
         @param _pendingGovernor Address of new Governor
     */
     function setPendingGovernor(address _pendingGovernor) external isGovernor {
-        require(_pendingGovernor != address(0), "MG:ZERO_ADDRESS_GOVERNOR");
+        require(_pendingGovernor != address(0), "MG:ZERO_ADDR");
         pendingGovernor = _pendingGovernor;
         emit PendingGovernorSet(_pendingGovernor);
     }
@@ -398,7 +398,7 @@ contract MapleGlobals {
         @dev It emits a `GovernorAccepted` event.
     */
     function acceptGovernor() external {
-        require(msg.sender == pendingGovernor, "MG:NOT_PENDING_GOVERNOR");
+        require(msg.sender == pendingGovernor, "MG:NOT_PENDING_GOV");
         governor = pendingGovernor;
         pendingGovernor = address(0);
         emit GovernorAccepted(governor);
@@ -446,6 +446,6 @@ contract MapleGlobals {
     /************************/
 
     function _checkPercentageRange(uint256 percentage) internal {
-        require(percentage >= uint256(0) && percentage <= uint256(10_000), "MG:PCT_BOUND_CHECK");
+        require(percentage <= uint256(10_000), "MG:PCT_OOB");
     }
 }

--- a/contracts/MapleTreasury.sol
+++ b/contracts/MapleTreasury.sol
@@ -49,7 +49,7 @@ contract MapleTreasury {
         @dev Checks that msg.sender is the Governor.
     */
     modifier isGovernor() {
-        require(msg.sender == IGlobals(globals).governor(), "MapleTreasury:MSG_SENDER_NOT_GOVERNOR");
+        require(msg.sender == IGlobals(globals).governor(), "MT:NOT_GOV");
         _;
     }
 
@@ -93,7 +93,7 @@ contract MapleTreasury {
         @param asset The ERC-20 asset to convert to fundsToken
     */
     function convertERC20(address asset) isGovernor public {
-        require(asset != fundsToken, "MapleTreasury:ASSET_EQUALS_FUNDS_TOKEN");
+        require(asset != fundsToken, "MT:ASSET_EQUALS_FUNDS_TOKEN");
 
         IGlobals _globals = IGlobals(globals);
 

--- a/contracts/MapleTreasury.sol
+++ b/contracts/MapleTreasury.sol
@@ -93,7 +93,7 @@ contract MapleTreasury {
         @param asset The ERC-20 asset to convert to fundsToken
     */
     function convertERC20(address asset) isGovernor public {
-        require(asset != fundsToken, "MT:ASSET_EQUALS_FUNDS_TOKEN");
+        require(asset != fundsToken, "MT:ASSET_IS_FUNDS_TOKEN");
 
         IGlobals _globals = IGlobals(globals);
 

--- a/contracts/MplRewards.sol
+++ b/contracts/MplRewards.sol
@@ -56,7 +56,7 @@ contract MplRewards is Ownable {
     }
 
     function _notPaused() internal view {
-        require(!paused, "REWARDS:CONTRACT_PAUSED");
+        require(!paused, "R:CONTRACT_PAUSED");
     }
 
     function totalSupply() external view returns (uint256) {
@@ -93,7 +93,7 @@ contract MplRewards is Ownable {
     function stake(uint256 amount) external {
         _notPaused();
         _updateReward(msg.sender);
-        require(amount > 0, "REWARDS:STAKE_EQ_ZERO");
+        require(amount > 0, "R:STAKE_EQ_ZERO");
         _totalSupply = _totalSupply.add(amount);
         _balances[msg.sender] = _balances[msg.sender].add(amount);
         stakingToken.safeTransferFrom(msg.sender, address(this), amount);
@@ -106,7 +106,7 @@ contract MplRewards is Ownable {
     function withdraw(uint256 amount) public {
         _notPaused();
         _updateReward(msg.sender);
-        require(amount > 0, "REWARDS:WITHDRAW_EQ_ZERO");
+        require(amount > 0, "R:WITHDRAW_EQ_ZERO");
         _totalSupply = _totalSupply.sub(amount);
         _balances[msg.sender] = _balances[msg.sender].sub(amount);
         stakingToken.safeTransfer(msg.sender, amount);
@@ -152,7 +152,7 @@ contract MplRewards is Ownable {
         // very high values of rewardRate in the earned and rewardsPerToken functions;
         // Reward + leftover must be less than 2^256 / 10^18 to avoid overflow.
         uint balance = rewardsToken.balanceOf(address(this));
-        require(rewardRate <= balance.div(rewardsDuration), "REWARDS:REWARD_TOO_HIGH");
+        require(rewardRate <= balance.div(rewardsDuration), "R:REWARD_TOO_HIGH");
 
         lastUpdateTime = block.timestamp;
         periodFinish   = block.timestamp.add(rewardsDuration);
@@ -173,7 +173,7 @@ contract MplRewards is Ownable {
         @dev It emits a `Recovered` event.
     */
     function recoverERC20(address tokenAddress, uint256 tokenAmount) external onlyOwner {
-        require(tokenAddress != address(stakingToken), "REWARDS:CANNOT_RECOVER_STAKE_TOKEN");
+        require(tokenAddress != address(stakingToken), "R:CANNOT_RECOVER_STAKE_TOKEN");
         IERC20(tokenAddress).safeTransfer(owner(), tokenAmount);
         emit Recovered(tokenAddress, tokenAmount);
     }
@@ -183,7 +183,7 @@ contract MplRewards is Ownable {
         @dev It emits a `RewardsDurationUpdated` event.
     */
     function setRewardsDuration(uint256 _rewardsDuration) external onlyOwner {
-        require(block.timestamp > periodFinish, "REWARDS:PERIOD_NOT_FINISHED");
+        require(block.timestamp > periodFinish, "R:PERIOD_NOT_FINISHED");
         rewardsDuration = _rewardsDuration;
         emit RewardsDurationUpdated(rewardsDuration);
     }
@@ -194,7 +194,7 @@ contract MplRewards is Ownable {
     */
     function setPaused(bool _paused) external onlyOwner {
         // Ensure we're actually changing the state before we do anything
-        require(_paused != paused, "MplRewards:ALREADY_IN_SAME_STATE");
+        require(_paused != paused, "R:ALREADY_IN_SAME_STATE");
 
         // Set our paused state.
         paused = _paused;

--- a/contracts/MplRewards.sol
+++ b/contracts/MplRewards.sol
@@ -56,7 +56,7 @@ contract MplRewards is Ownable {
     }
 
     function _notPaused() internal view {
-        require(!paused, "R:CONTRACT_PAUSED");
+        require(!paused, "R:PAUSED");
     }
 
     function totalSupply() external view returns (uint256) {
@@ -93,7 +93,7 @@ contract MplRewards is Ownable {
     function stake(uint256 amount) external {
         _notPaused();
         _updateReward(msg.sender);
-        require(amount > 0, "R:STAKE_EQ_ZERO");
+        require(amount > 0, "R:ZERO_STAKE");
         _totalSupply = _totalSupply.add(amount);
         _balances[msg.sender] = _balances[msg.sender].add(amount);
         stakingToken.safeTransferFrom(msg.sender, address(this), amount);
@@ -106,7 +106,7 @@ contract MplRewards is Ownable {
     function withdraw(uint256 amount) public {
         _notPaused();
         _updateReward(msg.sender);
-        require(amount > 0, "R:WITHDRAW_EQ_ZERO");
+        require(amount > 0, "R:ZERO_WITHDRAW");
         _totalSupply = _totalSupply.sub(amount);
         _balances[msg.sender] = _balances[msg.sender].sub(amount);
         stakingToken.safeTransfer(msg.sender, amount);
@@ -194,7 +194,7 @@ contract MplRewards is Ownable {
     */
     function setPaused(bool _paused) external onlyOwner {
         // Ensure we're actually changing the state before we do anything
-        require(_paused != paused, "R:ALREADY_IN_SAME_STATE");
+        require(_paused != paused, "R:ALREADY_SET");
 
         // Set our paused state.
         paused = _paused;

--- a/contracts/MplRewardsFactory.sol
+++ b/contracts/MplRewardsFactory.sol
@@ -22,7 +22,7 @@ contract MplRewardsFactory {
         @param _globals Address of new MapleGlobals contract
     */
     function setGlobals(address _globals) external {
-        require(msg.sender == globals.governor());
+        require(msg.sender == globals.governor(), "RF:NOT_GOV");
         globals = IGlobals(_globals);
     }
 
@@ -35,7 +35,7 @@ contract MplRewardsFactory {
         @return Address of the instantiated MplRewards
     */
     function createMplRewards(address rewardsToken, address stakingToken) external returns (address) {
-        require(msg.sender == globals.governor(), "MplRewardsFactory:UNAUTHORIZED");
+        require(msg.sender == globals.governor(), "RF:NOT_GOV");
         address mplRewards       = address(new MplRewards(rewardsToken, stakingToken, msg.sender));
         isMplRewards[mplRewards] = true;
 

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -144,7 +144,7 @@ contract Pool is PoolFDT {
         _isValidDelegateAndProtocolNotPaused();
         _isValidState(State.Initialized);
         (,, bool stakeSufficient,,) = getInitialStakeRequirements();
-        require(stakeSufficient, "Pool:INSUFFICIENT_STAKE");
+        require(stakeSufficient, "P:INSUFFICIENT_STAKE");
         poolState = State.Finalized;
         emit PoolStateChanged(poolState);
     }
@@ -301,7 +301,7 @@ contract Pool is PoolFDT {
      */
     function setLockupPeriod(uint256 newLockupPeriod) external {
         _isValidDelegateAndProtocolNotPaused();
-        require(newLockupPeriod <= lockupPeriod, "Pool:INVALID_VALUE");
+        require(newLockupPeriod <= lockupPeriod, "P:INVALID_VALUE");
         lockupPeriod = newLockupPeriod;
         emit LockupPeriodSet(newLockupPeriod);
     }
@@ -313,7 +313,7 @@ contract Pool is PoolFDT {
     */
     function setStakingFee(uint256 newStakingFee) external {
         _isValidDelegateAndProtocolNotPaused();
-        require(newStakingFee.add(delegateFee) <= 10_000, "Pool:INVALID_FEE");
+        require(newStakingFee.add(delegateFee) <= 10_000, "P:INVALID_FEE");
         stakingFee = newStakingFee;
         emit StakingFeeSet(newStakingFee);
     }
@@ -375,7 +375,7 @@ contract Pool is PoolFDT {
     function deposit(uint256 amt) external {
         _whenProtocolNotPaused();
         _isValidState(State.Finalized);
-        require(isDepositAllowed(amt), "Pool:NOT_ALLOWED");
+        require(isDepositAllowed(amt), "P:DEPOSIT_NOT_ALLOWED");
 
         withdrawCooldown[msg.sender] = uint256(0);  // Reset withdrawCooldown if LP had previously intended to withdraw
 
@@ -410,8 +410,8 @@ contract Pool is PoolFDT {
     function withdraw(uint256 amt) external {
         _whenProtocolNotPaused();
         uint256 wad = _toWad(amt);
-        require(PoolLib.isWithdrawAllowed(withdrawCooldown[msg.sender], _globals(superFactory)), "Pool:WITHDRAW_NOT_ALLOWED");
-        require(depositDate[msg.sender].add(lockupPeriod) <= block.timestamp,                    "Pool:FUNDS_LOCKED");
+        require(PoolLib.isWithdrawAllowed(withdrawCooldown[msg.sender], _globals(superFactory)), "P:WITHDRAW_NOT_ALLOWED");
+        require(depositDate[msg.sender].add(lockupPeriod) <= block.timestamp,                    "P:FUNDS_LOCKED");
 
         _burn(msg.sender, wad);  // Burn the corresponding FDT balance
         withdrawFunds();         // Transfer full entitled interest, decrement `interestSum`
@@ -577,14 +577,14 @@ contract Pool is PoolFDT {
         @param _state Enum of desired Pool state
     */
     function _isValidState(State _state) internal view {
-        require(poolState == _state, "Pool:INVALID_STATE");
+        require(poolState == _state, "P:INVALID_STATE");
     }
 
     /**
         @dev Checks that msg.sender is the Pool Delegate.
     */
     function _isValidDelegate() internal view {
-        require(msg.sender == poolDelegate, "Pool:INVALID_DELEGATE");
+        require(msg.sender == poolDelegate, "P:NOT_DELEGATE");
     }
 
     /**
@@ -614,14 +614,14 @@ contract Pool is PoolFDT {
         @dev Checks that msg.sender is the Pool Delegate or a Pool Admin.
     */
     function _isValidDelegateOrAdmin() internal {
-        require(msg.sender == poolDelegate || admins[msg.sender], "Pool:UNAUTHORIZED");
+        require(msg.sender == poolDelegate || admins[msg.sender], "P:NOT_DELEGATE_OR_ADMIN");
     }
 
     /**
         @dev Function to block functionality of functions when protocol is in a paused state.
     */
     function _whenProtocolNotPaused() internal {
-        require(!_globals(superFactory).protocolPaused(), "Pool:PROTOCOL_PAUSED");
+        require(!_globals(superFactory).protocolPaused(), "P:PROTOCOL_PAUSED");
     }
 
     /**

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -232,8 +232,6 @@ contract Pool is PoolFDT {
         emit BalanceUpdated(stakeLocker, address(liquidityAsset), liquidityAsset.balanceOf(stakeLocker));
 
         emit Claim(loan, interestClaim, principalClaim, claimInfo[3], stakeLockerPortion, poolDelegatePortion);
-
-        // TODO: Discuss with offchain team about requirements for return
     }
 
     /**

--- a/contracts/PoolFactory.sol
+++ b/contracts/PoolFactory.sol
@@ -70,7 +70,7 @@ contract PoolFactory is Pausable {
             IGlobals _globals = globals;
             require(_globals.isValidSubFactory(address(this), llFactory, LL_FACTORY), "PF:INVALID_LL_FACTORY");
             require(_globals.isValidSubFactory(address(this), slFactory, SL_FACTORY), "PF:INVALID_SL_FACTORY");
-            require(_globals.isValidPoolDelegate(msg.sender),                         "PF:INVALID_DELEGATE");
+            require(_globals.isValidPoolDelegate(msg.sender),                         "PF:NOT_DELEGATE");
         }
 
         string memory name   = string(abi.encodePacked("Maple Pool Token"));
@@ -140,14 +140,14 @@ contract PoolFactory is Pausable {
         @dev Checks that msg.sender is the Governor.
     */
     function _isValidGovernor() internal view {
-        require(msg.sender == globals.governor(), "PF:INVALID_GOVERNOR");
+        require(msg.sender == globals.governor(), "PF:NOT_GOV");
     }
 
     /**
         @dev Checks that msg.sender is the Governor or a Pool Factory Admin.
     */
     function _isValidGovernorOrAdmin() internal {
-        require(msg.sender == globals.governor() || admins[msg.sender], "PF:UNAUTHORIZED");
+        require(msg.sender == globals.governor() || admins[msg.sender], "PF:NOT_GOV_OR_ADMIN");
     }
 
     /**

--- a/contracts/PoolFactory.sol
+++ b/contracts/PoolFactory.sol
@@ -68,8 +68,8 @@ contract PoolFactory is Pausable {
         _whenProtocolNotPaused();
         {
             IGlobals _globals = globals;
-            require(_globals.isValidSubFactory(address(this), llFactory, LL_FACTORY), "PF:INVALID_LL_FACTORY");
-            require(_globals.isValidSubFactory(address(this), slFactory, SL_FACTORY), "PF:INVALID_SL_FACTORY");
+            require(_globals.isValidSubFactory(address(this), llFactory, LL_FACTORY), "PF:INVALID_LLF");
+            require(_globals.isValidSubFactory(address(this), slFactory, SL_FACTORY), "PF:INVALID_SLF");
             require(_globals.isValidPoolDelegate(msg.sender),                         "PF:NOT_DELEGATE");
         }
 
@@ -154,6 +154,6 @@ contract PoolFactory is Pausable {
         @dev Function to determine if protocol is paused/unpaused.
     */
     function _whenProtocolNotPaused() internal {
-        require(!globals.protocolPaused(), "PF:PROTOCOL_PAUSED");
+        require(!globals.protocolPaused(), "PF:PROTO_PAUSED");
     }
 }

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -65,7 +65,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         require(
             (msg.sender != IPool(pool).poolDelegate() && IPool(pool).isPoolFinalized()) ||
             !IPool(pool).isPoolFinalized(),
-            "SL:ERR_STAKE_LOCKED"
+            "SL:STAKE_LOCKED"
         );
         _;
     }
@@ -82,7 +82,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         @dev Checks that msg.sender is the Pool.
     */
     modifier isPool() {
-        require(msg.sender == pool, "SL:NOT_POOL");
+        require(msg.sender == pool, "SL:NOT_P");
         _;
     }
 
@@ -339,7 +339,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         @dev Function to block functionality of functions when protocol is in a paused state.
     */
     function _whenProtocolNotPaused() internal {
-        require(!_globals().protocolPaused(), "SL:PROTOCOL_PAUSED");
+        require(!_globals().protocolPaused(), "SL:PROTO_PAUSED");
     }
 
 }

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -65,7 +65,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         require(
             (msg.sender != IPool(pool).poolDelegate() && IPool(pool).isPoolFinalized()) ||
             !IPool(pool).isPoolFinalized(),
-            "StakeLocker:ERR_STAKE_LOCKED"
+            "SL:ERR_STAKE_LOCKED"
         );
         _;
     }
@@ -74,7 +74,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         @dev Checks that msg.sender is the Governor.
     */
     modifier isGovernor() {
-        require(msg.sender == _globals().governor(), "StakeLocker:MSG_SENDER_NOT_GOVERNOR");
+        require(msg.sender == _globals().governor(), "SL:NOT_GOV");
         _;
     }
 
@@ -82,7 +82,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         @dev Checks that msg.sender is the Pool.
     */
     modifier isPool() {
-        require(msg.sender == pool, "StakeLocker:MSG_SENDER_NOT_POOL");
+        require(msg.sender == pool, "SL:NOT_POOL");
         _;
     }
 
@@ -120,7 +120,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     function setLockupPeriod(uint256 newLockupPeriod) external {
         _whenProtocolNotPaused();
         _isValidPoolDelegate();
-        require(newLockupPeriod <= lockupPeriod, "StakeLocker:INVALID_VALUE");
+        require(newLockupPeriod <= lockupPeriod, "SL:INVALID_VALUE");
         lockupPeriod = newLockupPeriod;
         emit LockupPeriodUpdated(newLockupPeriod);
     }
@@ -194,7 +194,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         @dev It emits a `Cooldown` event.
     **/
     function intendToUnstake() external {
-        require(balanceOf(msg.sender) != uint256(0), "StakeLocker:ZERO_BALANCE");
+        require(balanceOf(msg.sender) != uint256(0), "SL:ZERO_BALANCE");
         unstakeCooldown[msg.sender] = block.timestamp;
         emit Cooldown(msg.sender, block.timestamp);
     }
@@ -204,7 +204,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         @dev It emits a `Cooldown` event.
      */
     function cancelUnstake() external {
-        require(unstakeCooldown[msg.sender] != uint256(0), "StakeLocker:NOT_UNSTAKING");
+        require(unstakeCooldown[msg.sender] != uint256(0), "SL:NOT_UNSTAKING");
         unstakeCooldown[msg.sender] = 0;
         emit Cooldown(msg.sender, uint256(0));
     }
@@ -217,8 +217,8 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     */
     function unstake(uint256 amt) external canUnstake {
         _whenProtocolNotPaused();
-        require(isUnstakeAllowed(msg.sender),                               "StakeLocker:OUTSIDE_COOLDOWN");
-        require(stakeDate[msg.sender].add(lockupPeriod) <= block.timestamp, "StakeLocker:FUNDS_LOCKED");
+        require(isUnstakeAllowed(msg.sender),                               "SL:OUTSIDE_COOLDOWN");
+        require(stakeDate[msg.sender].add(lockupPeriod) <= block.timestamp, "SL:FUNDS_LOCKED");
 
         updateFundsReceived();   // Account for any funds transferred into contract since last call
         _burn(msg.sender, amt);  // Burn the corresponding FDT balance.
@@ -256,8 +256,8 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     function _transfer(address from, address to, uint256 wad) internal override canUnstake {
         _whenProtocolNotPaused();
         if (!_globals().isExemptFromTransferRestriction(from) && !_globals().isExemptFromTransferRestriction(to)) {
-            require(isReceiveAllowed(unstakeCooldown[to]),    "StakeLocker:RECIPIENT_NOT_ALLOWED");  // Recipient must not be currently unstaking
-            require(recognizableLossesOf(from) == uint256(0), "StakeLocker:RECOG_LOSSES");           // If a staker has unrecognized losses, they must recognize losses through unstake
+            require(isReceiveAllowed(unstakeCooldown[to]),    "SL:RECIPIENT_NOT_ALLOWED");  // Recipient must not be currently unstaking
+            require(recognizableLossesOf(from) == uint256(0), "SL:RECOG_LOSSES");           // If a staker has unrecognized losses, they must recognize losses through unstake
             _updateStakeDate(to, wad);                                                               // Update stake date of recipient
         }
         super._transfer(from, to, wad);
@@ -308,14 +308,14 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         @dev Checks that msg.sender is the Pool Delegate or a Pool Admin.
     */
     function _isValidAdminOrPoolDelegate() internal view {
-        require(msg.sender == IPool(pool).poolDelegate() || IPool(pool).admins(msg.sender), "StakeLocker:UNAUTHORIZED");
+        require(msg.sender == IPool(pool).poolDelegate() || IPool(pool).admins(msg.sender), "SL:NOT_DELEGATE_OR_ADMIN");
     }
 
     /**
         @dev Checks that msg.sender is the Pool Delegate.
     */
     function _isValidPoolDelegate() internal view {
-        require(msg.sender == IPool(pool).poolDelegate(), "StakeLocker:UNAUTHORIZED");
+        require(msg.sender == IPool(pool).poolDelegate(), "SL:NOT_DELEGATE");
     }
 
     /**
@@ -324,7 +324,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     function _isAllowed(address user) internal view {
         require(
             openToPublic || allowed[user] || user == IPool(pool).poolDelegate(),
-            "StakeLocker:MSG_SENDER_NOT_ALLOWED"
+            "SL:NOT_ALLOWED"
         );
     }
 
@@ -339,7 +339,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         @dev Function to block functionality of functions when protocol is in a paused state.
     */
     function _whenProtocolNotPaused() internal {
-        require(!_globals().protocolPaused(), "StakeLocker:PROTOCOL_PAUSED");
+        require(!_globals().protocolPaused(), "SL:PROTOCOL_PAUSED");
     }
 
 }

--- a/contracts/library/LoanLib.sol
+++ b/contracts/library/LoanLib.sol
@@ -128,7 +128,7 @@ library LoanLib {
         @param globals Instance of the `MapleGlobals` contract.
      */
     function reclaimERC20(address token, address liquidityAsset, IGlobals globals) external {
-        require(msg.sender == globals.governor(), "L:NOT_GOV");
+        require(msg.sender == globals.governor(),               "L:NOT_GOV");
         require(token != liquidityAsset && token != address(0), "L:INVALID_TOKEN");
         IERC20(token).safeTransfer(msg.sender, IERC20(token).balanceOf(address(this)));
     }

--- a/contracts/library/LoanLib.sol
+++ b/contracts/library/LoanLib.sol
@@ -43,7 +43,7 @@ library LoanLib {
         IGlobals globals = _globals(superFactory);
 
         // Only callable if time has passed drawdown grace period, set in MapleGlobals
-        require(block.timestamp > createdAt.add(globals.fundingPeriod()), "Loan:FUNDING_PERIOD_NOT_FINISHED");
+        require(block.timestamp > createdAt.add(globals.fundingPeriod()), "L:FUNDING_PERIOD_NOT_FINISHED");
 
         uint256 preBal = liquidityAsset.balanceOf(address(this));  // Account for existing balance in Loan
 
@@ -128,8 +128,8 @@ library LoanLib {
         @param globals Instance of the `MapleGlobals` contract.
      */
     function reclaimERC20(address token, address liquidityAsset, IGlobals globals) external {
-        require(msg.sender == globals.governor(), "Loan:UNAUTHORIZED");
-        require(token != liquidityAsset && token != address(0), "Loan:INVALID_TOKEN");
+        require(msg.sender == globals.governor(), "L:NOT_GOV");
+        require(token != liquidityAsset && token != address(0), "L:INVALID_TOKEN");
         IERC20(token).safeTransfer(msg.sender, IERC20(token).balanceOf(address(this)));
     }
 

--- a/contracts/library/LoanLib.sol
+++ b/contracts/library/LoanLib.sol
@@ -43,7 +43,7 @@ library LoanLib {
         IGlobals globals = _globals(superFactory);
 
         // Only callable if time has passed drawdown grace period, set in MapleGlobals
-        require(block.timestamp > createdAt.add(globals.fundingPeriod()), "L:FUNDING_PERIOD_NOT_FINISHED");
+        require(block.timestamp > createdAt.add(globals.fundingPeriod()), "L:STILL_FUNDING_PERIOD");
 
         uint256 preBal = liquidityAsset.balanceOf(address(this));  // Account for existing balance in Loan
 

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -213,7 +213,9 @@ library PoolLib {
 
         // prevDate + (now - prevDate) * (amt / (balance + amt))
         // NOTE: prevDate = 0 implies balance = 0, and equation reduces to now
-        uint256 newDate = prevDate.add(block.timestamp.sub(prevDate).mul(amt).div(balance + amt));  
+        uint256 newDate = balance + amt > 0
+            ? prevDate.add(block.timestamp.sub(prevDate).mul(amt).div(balance + amt))
+            : prevDate;
 
         depositDate[who] = newDate;
 

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -210,14 +210,14 @@ library PoolLib {
     */
     function updateDepositDate(mapping(address => uint256) storage depositDate, uint256 balance, uint256 amt, address who) internal {
         uint256 prevDate = depositDate[who];
-
-        // prevDate + (now - prevDate) * (amt / (balance + amt))
-        // NOTE: prevDate = 0 implies balance = 0, and equation reduces to now
-        uint256 newDate = balance + amt > 0
-            ? prevDate.add(block.timestamp.sub(prevDate).mul(amt).div(balance + amt))
-            : prevDate;
-
-        depositDate[who] = newDate;
+        uint256 newDate = block.timestamp;
+        if (prevDate == uint256(0)) {
+            depositDate[who] = newDate;
+        } else {
+            uint256 dTime    = block.timestamp.sub(prevDate);
+            newDate          = prevDate.add(dTime.mul(amt).div(balance + amt));  // prevDate + (now - prevDate) * (amt / (balance + amt))
+            depositDate[who] = newDate;
+        }
 
         emit DepositDateUpdated(who, newDate);
     }

--- a/contracts/math/SafeMathInt.sol
+++ b/contracts/math/SafeMathInt.sol
@@ -3,7 +3,7 @@ pragma solidity 0.6.11;
 
 library SafeMathInt {
     function toUint256Safe(int256 a) internal pure returns (uint256) {
-        require(a >= 0);
+        require(a >= 0, "SMI:INVALID_VALUE");
         return uint256(a);
     }
 }

--- a/contracts/math/SafeMathInt.sol
+++ b/contracts/math/SafeMathInt.sol
@@ -3,7 +3,7 @@ pragma solidity 0.6.11;
 
 library SafeMathInt {
     function toUint256Safe(int256 a) internal pure returns (uint256) {
-        require(a >= 0, "SMI:INVALID_VALUE");
+        require(a >= 0, "SMI:NEG");
         return uint256(a);
     }
 }

--- a/contracts/math/SafeMathUint.sol
+++ b/contracts/math/SafeMathUint.sol
@@ -4,7 +4,7 @@ pragma solidity 0.6.11;
 library SafeMathUint {
     function toInt256Safe(uint256 a) internal pure returns (int256) {
         int256 b = int256(a);
-        require(b >= 0);
+        require(b >= 0, "SMU:INVALID_VALUE");
         return b;
     }
 }

--- a/contracts/math/SafeMathUint.sol
+++ b/contracts/math/SafeMathUint.sol
@@ -4,7 +4,7 @@ pragma solidity 0.6.11;
 library SafeMathUint {
     function toInt256Safe(uint256 a) internal pure returns (int256) {
         int256 b = int256(a);
-        require(b >= 0, "SMU:INVALID_VALUE");
+        require(b >= 0, "SMU:OOB");
         return b;
     }
 }

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -27,7 +27,7 @@ contract ChainlinkOracle is Ownable {
         @param _owner        Address of the owner of the contract
       */
     constructor(address _aggregator, address _assetAddress, address _owner) public {
-        require(_aggregator != address(0), "CO:INVALID_AGGREGATOR_ADDRESS");
+        require(_aggregator != address(0), "CO:ZERO_AGGREGATOR_ADDR");
         priceFeed       = IChainlinkAggregatorV3(_aggregator);
         assetAddress    = _assetAddress;
         transferOwnership(_owner);
@@ -50,7 +50,7 @@ contract ChainlinkOracle is Ownable {
         @param aggregator Address of chainlink aggregator
     */
     function changeAggregator(address aggregator) external onlyOwner {
-        require(aggregator != address(0), "CO:INVALID_AGGREGATOR_ADDRESS");
+        require(aggregator != address(0), "CO:ZERO_AGGREGATOR_ADDR");
         emit ChangeAggregatorFeed(aggregator, address(priceFeed));
         priceFeed = IChainlinkAggregatorV3(aggregator);
     }

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -27,7 +27,7 @@ contract ChainlinkOracle is Ownable {
         @param _owner        Address of the owner of the contract
       */
     constructor(address _aggregator, address _assetAddress, address _owner) public {
-        require(_aggregator != address(0), "ChainlinkOracle:INVALID_AGGREGATOR_ADDRESS");
+        require(_aggregator != address(0), "CO:INVALID_AGGREGATOR_ADDRESS");
         priceFeed       = IChainlinkAggregatorV3(_aggregator);
         assetAddress    = _assetAddress;
         transferOwnership(_owner);
@@ -39,7 +39,7 @@ contract ChainlinkOracle is Ownable {
     function getLatestPrice() public view returns (int256) {
         if (manualOverride) return manualPrice;
         (, int256 price,,,) = priceFeed.latestRoundData();
-        require(price != int256(0), "ChainlinkOracle:ZERO_PRICE");
+        require(price != int256(0), "CO:ZERO_PRICE");
         return price;
     }
 
@@ -50,7 +50,7 @@ contract ChainlinkOracle is Ownable {
         @param aggregator Address of chainlink aggregator
     */
     function changeAggregator(address aggregator) external onlyOwner {
-        require(aggregator != address(0), "ChainlinkOracle:INVALID_AGGREGATOR_ADDRESS");
+        require(aggregator != address(0), "CO:INVALID_AGGREGATOR_ADDRESS");
         emit ChangeAggregatorFeed(aggregator, address(priceFeed));
         priceFeed = IChainlinkAggregatorV3(aggregator);
     }


### PR DESCRIPTION
# Description

Rectify error-messsage-related issues raised by C4 and and normalize error messages code-wide.

Clubhouse: https://app.clubhouse.io/maplefinance/story/2036/maple-core-c4-error-messages

Slight error message and code refactor needed to  get back under contract size limits after handling original fixes.

# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [x] Has all documentation been updated?

# Changelog

- C4 error message issues 62, 63, 65 (see commit description for links)
- Standardized require error messages as "CONTRACT_ABBREVIATION:MESSAGE"
- Standardized all access error messages as "NOT_X[_OR_Y]"
- Added missing error messages for SafeMath contracts
- Fixed error message typo in LiquidityLocker contract
- Normalized all "LIQUIDITY" to "LIQ" in error messages
- Differentiated "NOT_ALLOWED" error messages
- Rephrased and/or abbreviated some error messages (i.e. _GOV_ernor, _O_ut _O_f _B_ounds, etc)
- Removed redundant bytecode in PoolLib, BasicFDT, ExtendedFDT, LoanFactory, MapleGlobals, Pool)
- Standardized error message abbreviations for common roles (_L_oan, _P_ool, _F_actory, etc)

## Function Signature Changes

## Features 

## Events

