### PR TITLE
fix: Pass in fundingPeriod from Loan storage (SC-2044)

### DIFF
--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -345,7 +345,7 @@ contract Loan is FDT, Pausable {
         _isValidState(State.Ready);
 
         // Update accounting for claim(), transfer funds from FundingLocker to Loan
-        excessReturned = LoanLib.unwind(liquidityAsset, superFactory, fundingLocker, createdAt);
+        excessReturned = LoanLib.unwind(liquidityAsset, superFactory, fundingLocker, createdAt, fundingPeriod);
 
         updateFundsReceived();
 

--- a/contracts/library/LoanLib.sol
+++ b/contracts/library/LoanLib.sol
@@ -37,13 +37,14 @@ library LoanLib {
         @param superFactory    Factory that instantiated Loan
         @param fundingLocker   Address of FundingLocker
         @param createdAt       Timestamp of Loan instantiation
+        @param fundingPeriod   Duration of funding period, after which funds can be reclaimed
         @return excessReturned Amount of liquidityAsset that was returned to the Loan from the FundingLocker
     */
-    function unwind(IERC20 liquidityAsset, address superFactory, address fundingLocker, uint256 createdAt) external returns(uint256 excessReturned) {
+    function unwind(IERC20 liquidityAsset, address superFactory, address fundingLocker, uint256 createdAt, uint256 fundingPeriod) external returns(uint256 excessReturned) {
         IMapleGlobals globals = _globals(superFactory);
 
         // Only callable if time has passed drawdown grace period, set in MapleGlobals
-        require(block.timestamp > createdAt.add(globals.fundingPeriod()), "L:STILL_FUNDING_PERIOD");
+        require(block.timestamp > createdAt.add(fundingPeriod), "L:STILL_FUNDING_PERIOD");
 
         uint256 preBal = liquidityAsset.balanceOf(address(this));  // Account for existing balance in Loan
 


### PR DESCRIPTION
# Description

Addresses https://github.com/code-423n4/2021-04-maple-findings/issues/100

# Integrations Checklist

- [x] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog
## Function Signature Changes

`LoanLib.unwind(IERC20 liquidityAsset, address superFactory, address fundingLocker, uint256 createdAt)`
`LoanLib.unwind(IERC20 liquidityAsset, address superFactory, address fundingLocker, uint256 createdAt, uint256 fundingPeriod)`

## Features 

## Events

