### PR TITLE
chore: Fixed an emit of CustodyAllowanceChanged, and some cleanup (SC-2092)

### DIFF
--- a/contracts/DebtLocker.sol
+++ b/contracts/DebtLocker.sol
@@ -40,7 +40,7 @@ contract DebtLocker {
     }
 
     // Note: If newAmt > 0, totalNewAmt will always be greater than zero.
-    function calcAllotment(uint256 newAmt, uint256 totalClaim, uint256 totalNewAmt) internal pure returns (uint256) {
+    function _calcAllotment(uint256 newAmt, uint256 totalClaim, uint256 totalNewAmt) internal pure returns (uint256) {
         return newAmt == uint256(0) ? uint256(0) : newAmt.mul(totalClaim).div(totalNewAmt);
     }
 
@@ -65,7 +65,7 @@ contract DebtLocker {
         // of LoanFDTs in comparison to the totalSupply of LoanFDTs.
         // Default will occur only once so below statement will only be `true` once.
         if (lastDefaultSuffered == uint256(0) && loan_defaultSuffered > uint256(0)) {
-            newDefaultSuffered = lastDefaultSuffered = calcAllotment(loan.balanceOf(address(this)), loan_defaultSuffered, loan.totalSupply());
+            newDefaultSuffered = lastDefaultSuffered = _calcAllotment(loan.balanceOf(address(this)), loan_defaultSuffered, loan.totalSupply());
         }
 
         // Account for any transfers into Loan that have occurred since last call
@@ -103,13 +103,13 @@ contract DebtLocker {
         uint256 sum = newInterest.add(newPrincipal).add(newFee).add(newExcess).add(newAmountRecovered);
 
         // Calculate payment portions based on LoanFDT claim
-        newInterest  = calcAllotment(newInterest,  claimBal, sum);
-        newPrincipal = calcAllotment(newPrincipal, claimBal, sum);
+        newInterest  = _calcAllotment(newInterest,  claimBal, sum);
+        newPrincipal = _calcAllotment(newPrincipal, claimBal, sum);
 
         // Calculate one-time portions based on LoanFDT claim
-        newFee             = calcAllotment(newFee,             claimBal, sum);
-        newExcess          = calcAllotment(newExcess,          claimBal, sum);
-        newAmountRecovered = calcAllotment(newAmountRecovered, claimBal, sum);
+        newFee             = _calcAllotment(newFee,             claimBal, sum);
+        newExcess          = _calcAllotment(newExcess,          claimBal, sum);
+        newAmountRecovered = _calcAllotment(newAmountRecovered, claimBal, sum);
 
         liquidityAsset.safeTransfer(pool, claimBal);  // Transfer entire amount claimed using LoanFDT
 

--- a/contracts/DebtLocker.sol
+++ b/contracts/DebtLocker.sol
@@ -54,7 +54,7 @@ contract DebtLocker {
                 [5] = Amount Recovered (from Liquidation)
                 [6] = Default Suffered
     */
-    function claim() external isPool returns(uint256[7] memory) {
+    function claim() external isPool returns (uint256[7] memory) {
 
         // Initialize newDefaultSuffered as zero
         uint256 newDefaultSuffered   = uint256(0);

--- a/contracts/LateFeeCalc.sol
+++ b/contracts/LateFeeCalc.sol
@@ -25,7 +25,7 @@ contract LateFeeCalc {
         @param  interest Amount of interest to be used to calculate late fee for.
         @return Late fee that is charged to borrower.
     */
-    function getLateFee(uint256 interest) external view returns(uint256) {
+    function getLateFee(uint256 interest) external view returns (uint256) {
         return interest.mul(lateFee).div(10_000);
     }
 }

--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -338,7 +338,7 @@ contract Loan is FDT, Pausable {
         _isValidState(State.Ready);
 
         // Update accounting for claim(), transfer funds from FundingLocker to Loan
-        excessReturned = LoanLib.unwind(liquidityAsset, superFactory, fundingLocker, createdAt, fundingPeriod);
+        excessReturned = LoanLib.unwind(liquidityAsset, fundingLocker, createdAt, fundingPeriod);
 
         updateFundsReceived();
 

--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -455,7 +455,7 @@ contract Loan is FDT, Pausable {
         @dev    Public getter to know how much minimum amount of loan asset will get by swapping collateral asset.
         @return Expected amount of liquidityAsset to be recovered from liquidation based on current oracle prices.
     */
-    function getExpectedAmountRecovered() external view returns(uint256) {
+    function getExpectedAmountRecovered() external view returns (uint256) {
         uint256 liquidationAmt = _getCollateralLockerBalance();
         return Util.calcMinAmount(_globals(superFactory), address(collateralAsset), address(liquidityAsset), liquidationAmt);
     }
@@ -468,7 +468,7 @@ contract Loan is FDT, Pausable {
                 [3] = Payment Due Date
                 [4] = Is Payment Late
     */
-    function getNextPayment() public view returns(uint256, uint256, uint256, uint256, bool) {
+    function getNextPayment() public view returns (uint256, uint256, uint256, uint256, bool) {
         return LoanLib.getNextPayment(repaymentCalc, nextPaymentDue, lateFeeCalc);
     }
 
@@ -478,7 +478,7 @@ contract Loan is FDT, Pausable {
         @return principal Principal owed.
         @return interest  Interest owed.
     */
-    function getFullPayment() public view returns(uint256 total, uint256 principal, uint256 interest) {
+    function getFullPayment() public view returns (uint256 total, uint256 principal, uint256 interest) {
         (total, principal, interest) = IPremiumCalc(premiumCalc).getPremiumPayment(address(this));
     }
 
@@ -487,7 +487,7 @@ contract Loan is FDT, Pausable {
         @param  amt The amount of liquidityAsset to draw down from FundingLocker.
         @return The amount of collateralAsset required to post in CollateralLocker for given drawdown amt.
     */
-    function collateralRequiredForDrawdown(uint256 amt) public view returns(uint256) {
+    function collateralRequiredForDrawdown(uint256 amt) public view returns (uint256) {
         return LoanLib.collateralRequiredForDrawdown(
             IERC20Details(address(collateralAsset)),
             IERC20Details(address(liquidityAsset)),
@@ -518,7 +518,7 @@ contract Loan is FDT, Pausable {
     /**
         @dev Utility to convert to WAD precision.
     */
-    function _toWad(uint256 amt) internal view returns(uint256) {
+    function _toWad(uint256 amt) internal view returns (uint256) {
         return amt.mul(10 ** 18).div(10 ** IERC20Details(address(liquidityAsset)).decimals());
     }
 

--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -430,7 +430,7 @@ contract Loan is FDT, Pausable {
     /**
         @dev   Transfer any locked funds to the governor. Only the Governor can call this function.
         @param token Address of the token that need to reclaimed.
-     */
+    */
     function reclaimERC20(address token) external {
         LoanLib.reclaimERC20(token, address(liquidityAsset), _globals(superFactory));
     }

--- a/contracts/MapleGlobals.sol
+++ b/contracts/MapleGlobals.sol
@@ -427,7 +427,7 @@ contract MapleGlobals {
                                 3 = LIQUIDITY_LOCKER_FACTORY
                                 4 = STAKE_LOCKER_FACTORY
     */
-    function isValidSubFactory(address superFactory, address subFactory, uint8 factoryType) external view returns(bool) {
+    function isValidSubFactory(address superFactory, address subFactory, uint8 factoryType) external view returns (bool) {
         return validSubFactories[superFactory][subFactory] && ISubFactory(subFactory).factoryType() == factoryType;
     }
 
@@ -436,7 +436,7 @@ contract MapleGlobals {
         @param calc     Calculator address.
         @param calcType Calculator type.
     */
-    function isValidCalc(address calc, uint8 calcType) external view returns(bool) {
+    function isValidCalc(address calc, uint8 calcType) external view returns (bool) {
         return validCalcs[calc] && ICalc(calc).calcType() == calcType;
     }
 

--- a/contracts/MapleGlobals.sol
+++ b/contracts/MapleGlobals.sol
@@ -108,7 +108,7 @@ contract MapleGlobals {
               Only the Governor can call this function.
         @dev  It emits a `GlobalsParamSet` event.
         @param newCooldownPeriod New value for the cool down period.
-     */
+    */
     function setStakerCooldownPeriod(uint256 newCooldownPeriod) external isGovernor {
         stakerCooldownPeriod = newCooldownPeriod;
         emit GlobalsParamSet("STAKER_COOLDOWN_PERIOD", newCooldownPeriod);
@@ -119,7 +119,7 @@ contract MapleGlobals {
                Only the Governor can call this function.
         @dev   It emits a `GlobalsParamSet` event.
         @param newCooldownPeriod New value for the cool down period.
-     */
+    */
     function setLpCooldownPeriod(uint256 newCooldownPeriod) external isGovernor {
         lpCooldownPeriod = newCooldownPeriod;
         emit GlobalsParamSet("LP_COOLDOWN_PERIOD", newCooldownPeriod);
@@ -130,7 +130,7 @@ contract MapleGlobals {
                Only the Governor can call this function.
         @dev   It emits a `GlobalsParamSet` event.
         @param newUnstakeWindow New value for the unstake window.
-     */
+    */
     function setStakerUnstakeWindow(uint256 newUnstakeWindow) external isGovernor {
         stakerUnstakeWindow = newUnstakeWindow;
         emit GlobalsParamSet("STAKER_UNSTAKE_WINDOW", newUnstakeWindow);
@@ -141,7 +141,7 @@ contract MapleGlobals {
                Only the Governor can call this function.
         @dev   It emits a `GlobalsParamSet` event.
         @param newLpWithdrawWindow New value for the withdraw window.
-     */
+    */
     function setLpWithdrawWindow(uint256 newLpWithdrawWindow) external isGovernor {
         lpWithdrawWindow = newLpWithdrawWindow;
         emit GlobalsParamSet("LP_WITHDRAW_WINDOW", newLpWithdrawWindow);
@@ -151,7 +151,7 @@ contract MapleGlobals {
         @dev   Update the allowed Uniswap slippage percentage, in basis points. Only the Governor can call this function.
         @dev   It emits a `GlobalsParamSet` event.
         @param newMaxSlippage New max slippage percentage (in basis points)
-     */
+    */
     function setMaxSwapSlippage(uint256 newMaxSlippage) external isGovernor {
         _checkPercentageRange(newMaxSlippage);
         maxSwapSlippage = newMaxSlippage;
@@ -162,7 +162,7 @@ contract MapleGlobals {
       @dev   Set global admin. Only the Governor can call this function.
       @dev   It emits a `GlobalAdminSet` event.
       @param newGlobalAdmin New global admin address.
-     */
+    */
     function setGlobalAdmin(address newGlobalAdmin) external {
         require(msg.sender == governor && newGlobalAdmin != address(0), "MG:NOT_GOV_OR_ADMIN");
         require(!protocolPaused, "MG:PROTO_PAUSED");

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -413,7 +413,7 @@ contract Pool is PoolFDT {
 
         // Transfer amount that is due after realized losses are accounted for.
         // recognizedLosses are absorbed by the LP.
-        _transferLiquidityLockerFunds(msg.sender, amt.sub(recognizeLosses()));
+        _transferLiquidityLockerFunds(msg.sender, amt.sub(_recognizeLosses()));
 
         _emitBalanceUpdatedEvent();
     }

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -174,7 +174,7 @@ contract Pool is PoolFDT {
                Only the Pool Delegate can call this function.
         @param loan      Address of the loan contract to liquidate.
         @param dlFactory Address of the debt locker factory that is used to pull corresponding debt locker.
-     */
+    */
     function triggerDefault(address loan, address dlFactory) external {
         _isValidDelegateAndProtocolNotPaused();
         IDebtLocker(debtLockers[loan][dlFactory]).triggerDefault();
@@ -302,7 +302,7 @@ contract Pool is PoolFDT {
         @dev   Set the lockup period. Only the Pool Delegate can call this function.
         @dev   It emits a `LockupPeriodSet` event.
         @param newLockupPeriod New lockup period used to restrict the withdrawals.
-     */
+    */
     function setLockupPeriod(uint256 newLockupPeriod) external {
         _isValidDelegateAndProtocolNotPaused();
         require(newLockupPeriod <= lockupPeriod, "P:INVALID_VALUE");
@@ -463,7 +463,7 @@ contract Pool is PoolFDT {
         @dev   Increase the custody allowance for a given `custodian` corresponds to `msg.sender`.
         @param custodian Address which will act as custodian of given `amount` for a tokenHolder.
         @param amount    Number of FDTs custodied by the custodian.
-     */
+    */
     function increaseCustodyAllowance(address custodian, uint256 amount) external {
         uint256 oldAllowance      = custodyAllowance[msg.sender][custodian];
         uint256 newAllowance      = oldAllowance.add(amount);
@@ -482,7 +482,7 @@ contract Pool is PoolFDT {
         @param from   Address which holds to Pool FDTs.
         @param to     Address which going to be the new owner of the `amount` FDTs.
         @param amount Number of FDTs transferred.
-     */
+    */
     function transferByCustodian(address from, address to, uint256 amount) external {
         uint256 oldAllowance = custodyAllowance[from][msg.sender];
         uint256 newAllowance = oldAllowance.sub(amount);
@@ -492,7 +492,7 @@ contract Pool is PoolFDT {
         custodyAllowance[from][msg.sender] = newAllowance;
         totalCustodyAllowance[from]        = totalCustodyAllowance[from].sub(amount);
         emit CustodyTransfer(msg.sender, from, to, amount);
-        emit CustodyAllowanceChanged(msg.sender, to, oldAllowance, newAllowance);
+        emit CustodyAllowanceChanged(from, msg.sender, oldAllowance, newAllowance);
     }
 
     /**************************/
@@ -572,7 +572,7 @@ contract Pool is PoolFDT {
     /**
       @dev    Checks that the Pool state is `Finalized`.
       @return bool Boolean value indicating if Pool is in a Finalized state.
-     */
+    */
     function isPoolFinalized() external view returns(bool) {
         return poolState == State.Finalized;
     }

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -590,7 +590,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev   Fetch the balance of this Pool's LiquidityLocker.
+        @dev    Fetch the balance of this Pool's LiquidityLocker.
         @return Balance of LiquidityLocker.
     */
     function _balanceOfLiquidityLocker() internal view returns (uint256) {

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -195,7 +195,7 @@ contract Pool is PoolFDT {
                     claimInfo [5] = Recovered portion claimed (from liquidations)
                     claimInfo [6] = Default suffered
     */
-    function claim(address loan, address dlFactory) external returns(uint256[7] memory claimInfo) {
+    function claim(address loan, address dlFactory) external returns (uint256[7] memory claimInfo) {
         _whenProtocolNotPaused();
         _isValidDelegateOrPoolAdmin();
         claimInfo = IDebtLocker(debtLockers[loan][dlFactory]).claim();
@@ -532,7 +532,7 @@ contract Pool is PoolFDT {
         @dev   Checks that the given `depositAmt` is acceptable based on current liquidityCap.
         @param depositAmt Amount of tokens (i.e liquidityAsset type) user is trying to deposit.
     */
-    function isDepositAllowed(uint256 depositAmt) public view returns(bool) {
+    function isDepositAllowed(uint256 depositAmt) public view returns (bool) {
         return (openToPublic || allowedLiquidityProviders[msg.sender]) &&
                _balanceOfLiquidityLocker().add(principalOut).add(depositAmt) <= liquidityCap;
     }
@@ -573,7 +573,7 @@ contract Pool is PoolFDT {
       @dev    Checks that the Pool state is `Finalized`.
       @return bool Boolean value indicating if Pool is in a Finalized state.
     */
-    function isPoolFinalized() external view returns(bool) {
+    function isPoolFinalized() external view returns (bool) {
         return poolState == State.Finalized;
     }
 
@@ -585,7 +585,7 @@ contract Pool is PoolFDT {
         @dev   Utility to convert to WAD precision.
         @param amt Amount to convert.
     */
-    function _toWad(uint256 amt) internal view returns(uint256) {
+    function _toWad(uint256 amt) internal view returns (uint256) {
         return amt.mul(WAD).div(10 ** liquidityAssetDecimals);
     }
 
@@ -593,7 +593,7 @@ contract Pool is PoolFDT {
         @dev   Fetch the balance of this Pool's LiquidityLocker.
         @return Balance of LiquidityLocker.
     */
-    function _balanceOfLiquidityLocker() internal view returns(uint256) {
+    function _balanceOfLiquidityLocker() internal view returns (uint256) {
         return liquidityAsset.balanceOf(liquidityLocker);
     }
 

--- a/contracts/PremiumCalc.sol
+++ b/contracts/PremiumCalc.sol
@@ -26,7 +26,7 @@ contract PremiumCalc {
         @return principalOwed Principal
         @return interest      Interest
     */
-    function getPremiumPayment(address _loan) external view returns(uint256 total, uint256 principalOwed, uint256 interest) {
+    function getPremiumPayment(address _loan) external view returns (uint256 total, uint256 principalOwed, uint256 interest) {
         principalOwed = ILoan(_loan).principalOwed();
         interest      = principalOwed.mul(premiumFee).div(10_000);
         total         = interest.add(principalOwed);

--- a/contracts/RepaymentCalc.sol
+++ b/contracts/RepaymentCalc.sol
@@ -20,7 +20,7 @@ contract RepaymentCalc {
         @return principalOwed Entitled principal amount needs to pay in the next payment.
         @return interest      Entitled interest amount needs to pay in the next payment.
     */
-    function getNextPayment(address _loan) external view returns(uint256 total, uint256 principalOwed, uint256 interest) {
+    function getNextPayment(address _loan) external view returns (uint256 total, uint256 principalOwed, uint256 interest) {
 
         ILoan loan = ILoan(_loan);
 

--- a/contracts/RepaymentCalc.sol
+++ b/contracts/RepaymentCalc.sol
@@ -36,8 +36,8 @@ contract RepaymentCalc {
                 .div(10_000)
                 .div(365 days);
 
-        return loan.paymentsRemaining() == 1
-            ? (interest.add(principalOwed), principalOwed, interest)
-            : (interest, 0, interest);
+        (total, principalOwed) = loan.paymentsRemaining() == 1
+            ? (interest.add(principalOwed), principalOwed)
+            : (interest, 0);
     }
 }

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -335,7 +335,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     /**
         @dev Helper function to return interface of MapleGlobals.
     */
-    function _globals() internal view returns(IMapleGlobals) {
+    function _globals() internal view returns (IMapleGlobals) {
         return IMapleGlobals(IPoolFactory(IPool(pool).superFactory()).globals());
     }
 

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -64,11 +64,8 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     modifier canUnstake(address from) {
         IPool _pool = IPool(pool);
 
-        require(
-            (from != _pool.poolDelegate() && _pool.isPoolFinalized()) ||
-            !_pool.isPoolFinalized(),
-            "SL:STAKE_LOCKED"
-        );
+        // Pool cannot be finalized, but if it is, user cannot be the Pool Delegate
+        require(!_pool.isPoolFinalized() || from != _pool.poolDelegate(), "SL:STAKE_LOCKED");
         _;
     }
 
@@ -120,7 +117,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         @dev   Set the lockup period. Only the Pool Delegate can call this function.
         @dev   It emits a `LockupPeriodUpdated` event.
         @param newLockupPeriod New lockup period used to restrict unstaking.
-     */
+    */
     function setLockupPeriod(uint256 newLockupPeriod) external {
         _whenProtocolNotPaused();
         _isValidPoolDelegate();
@@ -207,7 +204,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     /**
         @dev Cancels an initiated unstake by resetting unstakeCooldown.
         @dev It emits a `Cooldown` event.
-     */
+    */
     function cancelUnstake() external {
         require(unstakeCooldown[msg.sender] != uint256(0), "SL:NOT_UNSTAKING");
         unstakeCooldown[msg.sender] = 0;

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -227,7 +227,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         _burn(msg.sender, amt);  // Burn the corresponding FDT balance.
         withdrawFunds();         // Transfer full entitled liquidityAsset interest
 
-        stakeAsset.safeTransfer(msg.sender, amt.sub(recognizeLosses()));  // Unstake amt minus losses
+        stakeAsset.safeTransfer(msg.sender, amt.sub(_recognizeLosses()));  // Unstake amt minus losses
 
         emit Unstake(amt, msg.sender);
         emit BalanceUpdated(address(this), address(stakeAsset), stakeAsset.balanceOf(address(this)));

--- a/contracts/interfaces/IDebtLocker.sol
+++ b/contracts/interfaces/IDebtLocker.sol
@@ -20,7 +20,7 @@ interface IDebtLocker {
 
     function lastAmountRecovered() external view returns (uint256);
 
-    function claim() external returns(uint256[7] memory);
+    function claim() external returns (uint256[7] memory);
     
     function triggerDefault() external;
 }

--- a/contracts/interfaces/ILiquidityLocker.sol
+++ b/contracts/interfaces/ILiquidityLocker.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.6.11;
 
 interface ILiquidityLocker {
-    function pool() external view returns(address);
+    function pool() external view returns (address);
 
-    function liquidityAsset() external view returns(address);
+    function liquidityAsset() external view returns (address);
 
     function transfer(address, uint256) external;
 

--- a/contracts/interfaces/ILoan.sol
+++ b/contracts/interfaces/ILoan.sol
@@ -28,7 +28,7 @@ interface ILoan is IFDT {
     
     function loanState() external view returns (uint256);
     
-    function collateralRequiredForDrawdown(uint256) external view returns(uint256);
+    function collateralRequiredForDrawdown(uint256) external view returns (uint256);
     
 
     // Loan Specifications
@@ -76,9 +76,9 @@ interface ILoan is IFDT {
     
     function amountRecovered() external view returns (uint256);
     
-    function getExpectedAmountRecovered() external view returns(uint256);
+    function getExpectedAmountRecovered() external view returns (uint256);
 
-    function liquidationExcess() external view returns(uint256);
+    function liquidationExcess() external view returns (uint256);
     
 
     // Functions

--- a/contracts/interfaces/ILoanFactory.sol
+++ b/contracts/interfaces/ILoanFactory.sol
@@ -2,15 +2,15 @@
 pragma solidity 0.6.11;
 
 interface ILoanFactory {
-    function CL_FACTORY() external view returns(uint8);
+    function CL_FACTORY() external view returns (uint8);
 
-    function FL_FACTORY() external view returns(uint8);
+    function FL_FACTORY() external view returns (uint8);
 
-    function INTEREST_CALC_TYPE() external view returns(uint8);
+    function INTEREST_CALC_TYPE() external view returns (uint8);
 
-    function LATEFEE_CALC_TYPE() external view returns(uint8);
+    function LATEFEE_CALC_TYPE() external view returns (uint8);
 
-    function PREMIUM_CALC_TYPE() external view returns(uint8);
+    function PREMIUM_CALC_TYPE() external view returns (uint8);
 
     function globals() external view returns (address);
 

--- a/contracts/interfaces/IMapleGlobals.sol
+++ b/contracts/interfaces/IMapleGlobals.sol
@@ -52,17 +52,17 @@ interface IMapleGlobals {
 
     function protocolPaused() external view returns (bool);
 
-    function stakerCooldownPeriod() external view returns(uint256);
+    function stakerCooldownPeriod() external view returns (uint256);
 
-    function lpCooldownPeriod() external view returns(uint256);
+    function lpCooldownPeriod() external view returns (uint256);
 
-    function stakerUnstakeWindow() external view returns(uint256);
+    function stakerUnstakeWindow() external view returns (uint256);
 
-    function lpWithdrawWindow() external view returns(uint256);
+    function lpWithdrawWindow() external view returns (uint256);
 
-    function oracleFor(address) external view returns(address);
+    function oracleFor(address) external view returns (address);
 
-    function validSubFactories(address, address) external view returns(bool);
+    function validSubFactories(address, address) external view returns (bool);
 
     function setStakerCooldownPeriod(uint256) external;
 

--- a/contracts/interfaces/IOracle.sol
+++ b/contracts/interfaces/IOracle.sol
@@ -2,23 +2,23 @@
 pragma solidity 0.6.11;
 
 interface IOracle {
-    function priceFeed() external view returns(address);
+    function priceFeed() external view returns (address);
 
-    function globals() external view returns(address);
+    function globals() external view returns (address);
 
-    function assetAddress() external view returns(address);
+    function assetAddress() external view returns (address);
 
-    function manualOverride() external view returns(bool);
+    function manualOverride() external view returns (bool);
 
-    function manualPrice() external view returns(int256);
+    function manualPrice() external view returns (int256);
 
-    function getLatestPrice() external view returns(int256);
+    function getLatestPrice() external view returns (int256);
     
     function changeAggregator(address) external;
 
-    function getAssetAddress() external view returns(address);
+    function getAssetAddress() external view returns (address);
     
-    function getDenomination() external view returns(bytes32);
+    function getDenomination() external view returns (bytes32);
     
     function setManualPrice(int256) external;
     

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -85,6 +85,4 @@ interface IPool is IPoolFDT {
     function isDepositAllowed(uint256) external view returns (bool);
 
     function getInitialStakeRequirements() external view returns (uint256, uint256, bool, uint256, uint256);
-
-    function getInitialStakeRequirements(address, address, address, address, uint256) external view returns (uint256, uint256);
 }

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -14,13 +14,13 @@ interface IPool is IPoolFDT {
 
     function transferByCustodian(address, address, uint256) external;
 
-    function poolState() external view returns(uint256);
+    function poolState() external view returns (uint256);
 
     function deactivate() external;
 
     function finalize() external;
 
-    function claim(address, address) external returns(uint256[7] memory);
+    function claim(address, address) external returns (uint256[7] memory);
 
     function setLockupPeriod(uint256) external;
     
@@ -36,43 +36,43 @@ interface IPool is IPoolFDT {
 
     function triggerDefault(address, address) external;
 
-    function isPoolFinalized() external view returns(bool);
+    function isPoolFinalized() external view returns (bool);
 
     function setOpenToPublic(bool) external;
 
     function setAllowList(address, bool) external;
 
-    function allowedLiquidityProviders(address) external view returns(bool);
+    function allowedLiquidityProviders(address) external view returns (bool);
 
-    function openToPublic() external view returns(bool);
+    function openToPublic() external view returns (bool);
 
     function intendToWithdraw() external;
 
-    function DL_FACTORY() external view returns(uint8);
+    function DL_FACTORY() external view returns (uint8);
 
-    function liquidityAsset() external view returns(address);
+    function liquidityAsset() external view returns (address);
 
-    function liquidityLocker() external view returns(address);
+    function liquidityLocker() external view returns (address);
 
-    function stakeAsset() external view returns(address);
+    function stakeAsset() external view returns (address);
 
-    function stakeLocker() external view returns(address);
+    function stakeLocker() external view returns (address);
 
-    function stakingFee() external view returns(uint256);
+    function stakingFee() external view returns (uint256);
 
-    function delegateFee() external view returns(uint256);
+    function delegateFee() external view returns (uint256);
 
-    function principalOut() external view returns(uint256);
+    function principalOut() external view returns (uint256);
 
-    function liquidityCap() external view returns(uint256);
+    function liquidityCap() external view returns (uint256);
 
-    function lockupPeriod() external view returns(uint256);
+    function lockupPeriod() external view returns (uint256);
 
-    function depositDate(address) external view returns(uint256);
+    function depositDate(address) external view returns (uint256);
 
-    function debtLockers(address, address) external view returns(address);
+    function debtLockers(address, address) external view returns (address);
 
-    function withdrawCooldown(address) external view returns(uint256);
+    function withdrawCooldown(address) external view returns (uint256);
 
     function setLiquidityCap(uint256) external;
 
@@ -82,9 +82,9 @@ interface IPool is IPoolFDT {
 
     function BPTVal(address, address, address, address) external view returns (uint256);
 
-    function isDepositAllowed(uint256) external view returns(bool);
+    function isDepositAllowed(uint256) external view returns (bool);
 
-    function getInitialStakeRequirements() external view returns(uint256, uint256, bool, uint256, uint256);
+    function getInitialStakeRequirements() external view returns (uint256, uint256, bool, uint256, uint256);
 
-    function getInitialStakeRequirements(address, address, address, address, uint256) external view returns(uint256, uint256);
+    function getInitialStakeRequirements(address, address, address, address, uint256) external view returns (uint256, uint256);
 }

--- a/contracts/interfaces/IStakeLocker.sol
+++ b/contracts/interfaces/IStakeLocker.sol
@@ -24,9 +24,9 @@ interface IStakeLocker is IStakeLockerFDT {
 
     function intendToUnstake() external;
 
-    function unstakeCooldown(address) external view returns(uint256);
+    function unstakeCooldown(address) external view returns (uint256);
 
-    function lockupPeriod() external view returns(uint256);
+    function lockupPeriod() external view returns (uint256);
 
     function stakeAsset() external view returns (address);
 

--- a/contracts/library/LoanLib.sol
+++ b/contracts/library/LoanLib.sol
@@ -37,7 +37,7 @@ library LoanLib {
         @param  fundingPeriod  Duration of funding period, after which funds can be reclaimed.
         @return excessReturned Amount of liquidityAsset that was returned to the Loan from the FundingLocker.
     */
-    function unwind(IERC20 liquidityAsset, address fundingLocker, uint256 createdAt, uint256 fundingPeriod) external returns(uint256 excessReturned) {
+    function unwind(IERC20 liquidityAsset, address fundingLocker, uint256 createdAt, uint256 fundingPeriod) external returns (uint256 excessReturned) {
         // Only callable if time has passed drawdown grace period, set in MapleGlobals
         require(block.timestamp > createdAt.add(fundingPeriod), "L:STILL_FUNDING_PERIOD");
 
@@ -138,7 +138,7 @@ library LoanLib {
         @param  totalSupply        LoanFDT totalSupply.
         @return boolean indicating if default can be triggered.
     */
-    function canTriggerDefault(uint256 nextPaymentDue, uint256 defaultGracePeriod, address superFactory, uint256 balance, uint256 totalSupply) external view returns(bool) {
+    function canTriggerDefault(uint256 nextPaymentDue, uint256 defaultGracePeriod, address superFactory, uint256 balance, uint256 totalSupply) external view returns (bool) {
         bool pastDefaultGracePeriod = block.timestamp > nextPaymentDue.add(defaultGracePeriod);
 
         // Check if the loan is past the defaultGracePeriod and that `msg.sender` has a percentage of total LoanFDTs that is greater
@@ -231,7 +231,7 @@ library LoanLib {
         return IMapleGlobals(ILoanFactory(loanFactory).globals());
     }
 
-    function _toWad(uint256 amt, IERC20Details liquidityAsset) internal view returns(uint256) {
+    function _toWad(uint256 amt, IERC20Details liquidityAsset) internal view returns (uint256) {
         return amt.mul(10 ** 18).div(10 ** liquidityAsset.decimals());
     }
 }

--- a/contracts/library/LoanLib.sol
+++ b/contracts/library/LoanLib.sol
@@ -32,15 +32,12 @@ library LoanLib {
     /**
         @dev    If the borrower has not drawn down loan past grace period, return capital to lenders.
         @param  liquidityAsset IERC20 of the liquidityAsset.
-        @param  superFactory   Factory that instantiated Loan.
         @param  fundingLocker  Address of FundingLocker.
         @param  createdAt      Timestamp of Loan instantiation.
         @param  fundingPeriod  Duration of funding period, after which funds can be reclaimed.
         @return excessReturned Amount of liquidityAsset that was returned to the Loan from the FundingLocker.
     */
-    function unwind(IERC20 liquidityAsset, address superFactory, address fundingLocker, uint256 createdAt, uint256 fundingPeriod) external returns(uint256 excessReturned) {
-        IMapleGlobals globals = _globals(superFactory);
-
+    function unwind(IERC20 liquidityAsset, address fundingLocker, uint256 createdAt, uint256 fundingPeriod) external returns(uint256 excessReturned) {
         // Only callable if time has passed drawdown grace period, set in MapleGlobals
         require(block.timestamp > createdAt.add(fundingPeriod), "L:STILL_FUNDING_PERIOD");
 

--- a/contracts/library/LoanLib.sol
+++ b/contracts/library/LoanLib.sol
@@ -121,7 +121,7 @@ library LoanLib {
         @param token          Address of the token that need to reclaimed.
         @param liquidityAsset Address of loan asset that is supported by the loan in other words denominated currency in which it taking funds.
         @param globals        Instance of the `MapleGlobals` contract.
-     */
+    */
     function reclaimERC20(address token, address liquidityAsset, IMapleGlobals globals) external {
         require(msg.sender == globals.governor(),               "L:NOT_GOV");
         require(token != liquidityAsset && token != address(0), "L:INVALID_TOKEN");

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -105,7 +105,7 @@ library PoolLib {
         @return bptsBurned                      Amount of BPTs burned to cover shortfall.
         @return postBurnBptBal                  Amount of BPTs returned to stakeLocker after burn.
         @return liquidityAssetRecoveredFromBurn Amount of liquidityAsset recovered from burn.
-     */
+    */
     function handleDefault(
         IERC20  liquidityAsset,
         address stakeLocker,
@@ -261,7 +261,7 @@ library PoolLib {
     /**
         @dev Performs all necessary checks for a `transferByCustodian` call.
         @dev From and to must always be equal.
-     */
+    */
     function transferByCustodianChecks(address from, address to, uint256 amount, uint256 custodyAllowance) external {
         require(to == from,                 "P:INVALID_RECEIVER");
         require(amount != uint256(0),       "P:INVALID_AMT");
@@ -270,7 +270,7 @@ library PoolLib {
 
     /**
         @dev Performs all necessary checks for a `increaseCustodyAllowance` call
-     */
+    */
     function increaseCustodyAllowanceChecks(address custodian, uint256 amount, uint256 newTotalAllowance, uint256 fdtBal) external {
         require(custodian != address(0),     "P:INVALID_CUSTODIAN");
         require(amount    != uint256(0),     "P:INVALID_AMT");
@@ -280,7 +280,7 @@ library PoolLib {
     /**
         @dev Activates the cooldown period to withdraw. It can't be called if the user is not an LP.
         @dev It emits a `Cooldown` event.
-     */
+    */
     function intendToWithdraw(mapping(address => uint256) storage withdrawCooldown, uint256 balance) external {
         require(balance != uint256(0), "P:ZERO_BALANCE");
         withdrawCooldown[msg.sender] = block.timestamp;
@@ -290,7 +290,7 @@ library PoolLib {
     /**
         @dev Cancel an initiated withdrawal.
         @dev It emits a `Cooldown` event.
-     */
+    */
     function cancelWithdraw(mapping(address => uint256) storage withdrawCooldown) external {
         require(withdrawCooldown[msg.sender] != uint256(0), "P:NOT_WITHDRAWING");
         withdrawCooldown[msg.sender] = uint256(0);
@@ -306,7 +306,7 @@ library PoolLib {
         @param token          Address of the token that need to reclaimed.
         @param liquidityAsset Address of liquidity asset that is supported by the pool.
         @param globals        Instance of the `MapleGlobals` contract.
-     */
+    */
     function reclaimERC20(address token, address liquidityAsset, IMapleGlobals globals) external {
         require(msg.sender == globals.governor(), "P:NOT_GOV");
         require(token != liquidityAsset && token != address(0), "P:INVALID_TOKEN");

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -191,7 +191,7 @@ library PoolLib {
         @param liquidityAsset Liquidity Asset of the pool.
     */
     function validateDeactivation(IMapleGlobals globals, uint256 principalOut, address liquidityAsset) external view {
-        require(principalOut <= convertFromUsd(globals, liquidityAsset, 100), "P:PRINCIPAL_OUTSTANDING");
+        require(principalOut <= _convertFromUsd(globals, liquidityAsset, 100), "P:PRINCIPAL_OUTSTANDING");
     }
 
     /********************************************/
@@ -262,7 +262,7 @@ library PoolLib {
         @dev Performs all necessary checks for a `transferByCustodian` call.
         @dev From and to must always be equal.
     */
-    function transferByCustodianChecks(address from, address to, uint256 amount, uint256 custodyAllowance) external {
+    function transferByCustodianChecks(address from, address to, uint256 amount, uint256 custodyAllowance) external pure {
         require(to == from,                 "P:INVALID_RECEIVER");
         require(amount != uint256(0),       "P:INVALID_AMT");
         require(custodyAllowance >= amount, "P:INSUFFICIENT_ALLOWANCE");
@@ -271,7 +271,7 @@ library PoolLib {
     /**
         @dev Performs all necessary checks for a `increaseCustodyAllowance` call
     */
-    function increaseCustodyAllowanceChecks(address custodian, uint256 amount, uint256 newTotalAllowance, uint256 fdtBal) external {
+    function increaseCustodyAllowanceChecks(address custodian, uint256 amount, uint256 newTotalAllowance, uint256 fdtBal) external pure {
         require(custodian != address(0),     "P:INVALID_CUSTODIAN");
         require(amount    != uint256(0),     "P:INVALID_AMT");
         require(newTotalAllowance <= fdtBal, "P:INSUFFICIENT_BALANCE");
@@ -483,7 +483,7 @@ library PoolLib {
         uint256 poolAmountInRequired,
         uint256 poolAmountPresent
     ) {
-        swapOutAmountRequired = convertFromUsd(globals, liquidityAsset, globals.swapOutRequired());
+        swapOutAmountRequired = _convertFromUsd(globals, liquidityAsset, globals.swapOutRequired());
         (
             poolAmountInRequired,
             poolAmountPresent
@@ -522,7 +522,7 @@ library PoolLib {
         @param  usdAmount      USD amount to convert, in integer units (e.g., $100 = 100).
         @return usdAmount worth of liquidityAsset, in liquidityAsset units.
     */
-    function convertFromUsd(IMapleGlobals globals, address liquidityAsset, uint256 usdAmount) internal view returns (uint256) {
+    function _convertFromUsd(IMapleGlobals globals, address liquidityAsset, uint256 usdAmount) internal view returns (uint256) {
         return usdAmount
             .mul(10 ** 8)                                         // Cancel out 10 ** 8 decimals from oracle
             .mul(10 ** IERC20Details(liquidityAsset).decimals())  // Convert to liquidityAsset precision

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -502,7 +502,7 @@ library PoolLib {
         @param amt                    Amount to convert.
         @param liquidityAssetDecimals Liquidity asset decimal.
     */
-    function fromWad(uint256 amt, uint256 liquidityAssetDecimals) public pure returns(uint256) {
+    function fromWad(uint256 amt, uint256 liquidityAssetDecimals) public pure returns (uint256) {
         return amt.mul(10 ** liquidityAssetDecimals).div(WAD);
     }
 

--- a/contracts/library/Util.sol
+++ b/contracts/library/Util.sol
@@ -18,7 +18,7 @@ library Util {
         @param  swapAmt   Amount of fromAsset to be swapped.
         @return Expected amount of toAsset to receive from swap based on current oracle prices.
     */
-    function calcMinAmount(IMapleGlobals globals, address fromAsset, address toAsset, uint256 swapAmt) external view returns(uint256) {
+    function calcMinAmount(IMapleGlobals globals, address fromAsset, address toAsset, uint256 swapAmt) external view returns (uint256) {
         return 
             swapAmt
                 .mul(globals.getLatestPrice(fromAsset))           // Convert from "from" asset value

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -62,14 +62,14 @@ contract ChainlinkOracle is Ownable {
     /**
         @dev Returns address of oracle currency (0x0 for ETH).
     */
-    function getAssetAddress() external view returns(address) {
+    function getAssetAddress() external view returns (address) {
         return assetAddress;
     }
 
     /**
        @dev Returns denomination of price.
     */
-    function getDenomination() external pure returns(bytes32) {
+    function getDenomination() external pure returns (bytes32) {
         // All Chainlink oracles are denominated in USD
         return bytes32("USD");
     }

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -36,7 +36,7 @@ contract ChainlinkOracle is Ownable {
     /**
         @dev    Returns the latest price.
         @return price The latest price.
-     */
+    */
     function getLatestPrice() public view returns (int256) {
         if (manualOverride) return manualPrice;
         (uint80 roundID, int256 price,,uint256 timeStamp, uint80 answeredInRound) = priceFeed.latestRoundData();

--- a/contracts/test/PoolClaim.t.sol
+++ b/contracts/test/PoolClaim.t.sol
@@ -536,17 +536,17 @@ contract PoolTest is TestUtil {
     /*** Helpers ***/
     /***************/
 
-    function assertConstFundLoan(Pool pool, address _loan, address dlFactory, uint256 amt, IERC20 liquidityAsset, uint256 constPoolVal) internal returns(bool) {
+    function assertConstFundLoan(Pool pool, address _loan, address dlFactory, uint256 amt, IERC20 liquidityAsset, uint256 constPoolVal) internal returns (bool) {
         assertTrue(pat.try_fundLoan(address(pool), _loan,  dlFactory, amt));
         assertTrue(isConstantPoolValue(pool, liquidityAsset, constPoolVal));
     }
 
-    function assertConstClaim(Pool pool, address _loan, address dlFactory, IERC20 liquidityAsset, uint256 constPoolVal) internal returns(bool) {
+    function assertConstClaim(Pool pool, address _loan, address dlFactory, IERC20 liquidityAsset, uint256 constPoolVal) internal returns (bool) {
         pat.claim(address(pool), _loan, dlFactory);
         assertTrue(isConstantPoolValue(pool, liquidityAsset, constPoolVal));
     }
 
-    function isConstantPoolValue(Pool pool, IERC20 liquidityAsset, uint256 constPoolVal) internal view returns(bool) {
+    function isConstantPoolValue(Pool pool, IERC20 liquidityAsset, uint256 constPoolVal) internal view returns (bool) {
         return pool.principalOut() + liquidityAsset.balanceOf(pool.liquidityLocker()) == constPoolVal;
     }
 
@@ -554,7 +554,7 @@ contract PoolTest is TestUtil {
         return newAmt == uint256(0) ? uint256(0) : newAmt.mul(totalClaim).div(totalNewAmt);
     }
 
-    function getDL(Pool pool, Loan loan, DebtLockerFactory dlFactory) internal view returns(address) {
+    function getDL(Pool pool, Loan loan, DebtLockerFactory dlFactory) internal view returns (address) {
         return pool.debtLockers(address(loan), address(dlFactory));
     }
 
@@ -564,7 +564,7 @@ contract PoolTest is TestUtil {
         uint256 numPayments,
         uint256 requestAmount,
         uint256 collateralRatio
-    ) internal returns(uint256 depositAmt) {
+    ) internal returns (uint256 depositAmt) {
         uint256[5] memory specs = getFuzzedSpecs(apr, index, numPayments, requestAmount, collateralRatio);
         address[3] memory calcs = [address(repaymentCalc), address(lateFeeCalc), address(premiumCalc)];
 
@@ -579,7 +579,7 @@ contract PoolTest is TestUtil {
         }
     }
     
-    function getLoanFundedAmounts(uint256 beforeLLBalance, uint256 rounds, uint256 loan1FundedCount, uint256 loan2FundedCount) internal returns(uint256, uint256[] memory) {
+    function getLoanFundedAmounts(uint256 beforeLLBalance, uint256 rounds, uint256 loan1FundedCount, uint256 loan2FundedCount) internal returns (uint256, uint256[] memory) {
         uint256 maxAmountPerFundLoan = beforeLLBalance / rounds;
         uint256 totalFundedAmount    = 0;
 

--- a/contracts/test/PoolFactory.t.sol
+++ b/contracts/test/PoolFactory.t.sol
@@ -28,7 +28,7 @@ contract PoolFactoryTest is TestUtil {
         assertEq(address(poolFactory.globals()), address(globals2));                   // Globals is updated
     }
 
-    function createPoolFails() internal returns(bool) {
+    function createPoolFails() internal returns (bool) {
         return !pat.try_createPool(
             address(poolFactory),
             USDC,

--- a/contracts/test/StakeLocker.t.sol
+++ b/contracts/test/StakeLocker.t.sol
@@ -22,7 +22,7 @@ contract StakeLockerTest is TestUtil {
         createLoan();
     }
 
-    function getNewStakeDate(address who, uint256 amt) public returns(uint256 newStakeDate) {
+    function getNewStakeDate(address who, uint256 amt) public returns (uint256 newStakeDate) {
         // Keeping original test logic different from counterpart code to ensure continued expected behaviour (for now)
         uint256 prevDate = stakeLocker.stakeDate(who);
         if (prevDate == uint256(0)) {

--- a/contracts/test/TestUtil.sol
+++ b/contracts/test/TestUtil.sol
@@ -594,11 +594,11 @@ contract TestUtil is DSTest {
         }
     }
 
-    function constrictToRange(uint256 val, uint256 min, uint256 max) public pure returns(uint256) {
+    function constrictToRange(uint256 val, uint256 min, uint256 max) public pure returns (uint256) {
         return constrictToRange(val, min, max, false);
     }
 
-    function constrictToRange(uint256 val, uint256 min, uint256 max, bool nonZero) public pure returns(uint256) {
+    function constrictToRange(uint256 val, uint256 min, uint256 max, bool nonZero) public pure returns (uint256) {
         if      (val == 0 && !nonZero) return 0;
         else if (max == min)           return max;
         else                           return val % (max - min) + min;
@@ -680,7 +680,7 @@ contract TestUtil is DSTest {
         bow.drawdown(address(loan),  usdDrawdownAmt);
     }
 
-    function doPartialLoanPayment(Loan loan, Borrower bow) internal returns(uint256 amt) {
+    function doPartialLoanPayment(Loan loan, Borrower bow) internal returns (uint256 amt) {
         (amt,,,,) = loan.getNextPayment(); // USDC required for next payment of loan
         mint("USDC", address(bow), amt);
         bow.approve(USDC, address(loan),  amt);
@@ -731,7 +731,7 @@ contract TestUtil is DSTest {
         hevm.warp(currentTime + globals.lpCooldownPeriod());
     }
 
-    function toWad(uint256 amt) internal view returns(uint256) {
+    function toWad(uint256 amt) internal view returns (uint256) {
         return amt.mul(WAD).div(USD);
     }
 

--- a/contracts/test/TestUtil.sol
+++ b/contracts/test/TestUtil.sol
@@ -637,7 +637,7 @@ contract TestUtil is DSTest {
     /*** Yield Farming Helpers ***/
     /*****************************/
     function setUpFarming(uint256 totalMpl, uint256 rewardsDuration) internal {
-        mpl.transfer(address(gov), totalMpl);              // Transfer MPL to MplRewards
+        mpl.transfer(address(gov), totalMpl);              // Transfer MPL to Governor
         gov.transfer(mpl, address(mplRewards), totalMpl);  // Transfer MPL to MplRewards
         gov.setRewardsDuration(rewardsDuration);
         gov.notifyRewardAmount(totalMpl);

--- a/contracts/test/user/Borrower.sol
+++ b/contracts/test/user/Borrower.sol
@@ -107,17 +107,17 @@ contract Borrower {
         (ok,) = address(locker).call(abi.encodeWithSignature(sig, dst, amt));
     }
 
-    function try_setLoanAdmin(address loan, address newLoanAdmin, bool status) external returns(bool ok) {
+    function try_setLoanAdmin(address loan, address newLoanAdmin, bool status) external returns (bool ok) {
         string memory sig = "setLoanAdmin(address,bool)";
         (ok,) = address(loan).call(abi.encodeWithSignature(sig, newLoanAdmin, status));
     }
 
-    function try_pause(address target) external returns(bool ok) {
+    function try_pause(address target) external returns (bool ok) {
         string memory sig = "pause()";
         (ok,) = target.call(abi.encodeWithSignature(sig));
     }
 
-    function try_unpause(address target) external returns(bool ok) {
+    function try_unpause(address target) external returns (bool ok) {
         string memory sig = "unpause()";
         (ok,) = target.call(abi.encodeWithSignature(sig));
     }

--- a/contracts/test/user/Commoner.sol
+++ b/contracts/test/user/Commoner.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 
 contract Commoner {
 
-    function try_setLiquidityCap(address pool, uint256 liquidityCap) external returns(bool ok) {
+    function try_setLiquidityCap(address pool, uint256 liquidityCap) external returns (bool ok) {
         string memory sig = "setLiquidityCap(uint256)";
         (ok,) = address(pool).call(abi.encodeWithSignature(sig, liquidityCap));
     }

--- a/contracts/test/user/Governor.sol
+++ b/contracts/test/user/Governor.sol
@@ -257,17 +257,17 @@ contract Governor {
     }
 
     /*** Pool Functions ***/
-    function try_reclaimERC20(address target, address token) external returns(bool ok) {
+    function try_reclaimERC20(address target, address token) external returns (bool ok) {
         string memory sig = "reclaimERC20(address)";
         (ok,) = target.call(abi.encodeWithSignature(sig, token));
     }
 
     /*** PoolFactory/LoanFactory Functions ***/
-    function try_pause(address target) external returns(bool ok) {
+    function try_pause(address target) external returns (bool ok) {
         string memory sig = "pause()";
         (ok,) = target.call(abi.encodeWithSignature(sig));
     }
-    function try_unpause(address target) external returns(bool ok) {
+    function try_unpause(address target) external returns (bool ok) {
         string memory sig = "unpause()";
         (ok,) = target.call(abi.encodeWithSignature(sig));
     }

--- a/contracts/test/user/LP.sol
+++ b/contracts/test/user/LP.sol
@@ -41,12 +41,12 @@ contract LP {
         (ok,) = address(pool1).call(abi.encodeWithSignature(sig, amt));
     }
 
-    function try_withdraw(address pool, uint256 amt) external returns(bool ok) {
+    function try_withdraw(address pool, uint256 amt) external returns (bool ok) {
         string memory sig = "withdraw(uint256)";
         (ok,) = pool.call(abi.encodeWithSignature(sig, amt));
     }
 
-    function try_withdrawFunds(address pool) external returns(bool ok) {
+    function try_withdrawFunds(address pool) external returns (bool ok) {
         string memory sig = "withdrawFunds()";
         (ok,) = pool.call(abi.encodeWithSignature(sig));
     }

--- a/contracts/test/user/Lender.sol
+++ b/contracts/test/user/Lender.sol
@@ -53,12 +53,12 @@ contract Lender {
         (ok,) = loan.call(abi.encodeWithSignature(sig));
     }
 
-    function try_withdrawFunds(address loan) external returns(bool ok) {
+    function try_withdrawFunds(address loan) external returns (bool ok) {
         string memory sig = "withdrawFunds()";
         (ok,) = loan.call(abi.encodeWithSignature(sig));
     }
 
-    function try_triggerDefault(address loan) external returns(bool ok) {
+    function try_triggerDefault(address loan) external returns (bool ok) {
         string memory sig = "triggerDefault()";
         (ok,) = address(loan).call(abi.encodeWithSignature(sig));
     }

--- a/contracts/test/user/PoolDelegate.sol
+++ b/contracts/test/user/PoolDelegate.sol
@@ -62,7 +62,7 @@ contract PoolDelegate {
         ILoan(loan).unwind();
     }
 
-    function claim(address pool, address loan, address dlFactory) external returns(uint256[7] memory) {
+    function claim(address pool, address loan, address dlFactory) external returns (uint256[7] memory) {
         return IPool(pool).claim(loan, dlFactory);
     }
 
@@ -148,62 +148,62 @@ contract PoolDelegate {
         (ok,) = address(pool).call(abi.encodeWithSignature(sig));
     }
 
-    function try_deactivate(address pool) external returns(bool ok) {
+    function try_deactivate(address pool) external returns (bool ok) {
         string memory sig = "deactivate()";
         (ok,) = address(pool).call(abi.encodeWithSignature(sig));
     }
 
-    function try_setLiquidityCap(address pool, uint256 liquidityCap) external returns(bool ok) {
+    function try_setLiquidityCap(address pool, uint256 liquidityCap) external returns (bool ok) {
         string memory sig = "setLiquidityCap(uint256)";
         (ok,) = address(pool).call(abi.encodeWithSignature(sig, liquidityCap));
     }
 
-    function try_setLockupPeriod(address pool, uint256 newPeriod) external returns(bool ok) {
+    function try_setLockupPeriod(address pool, uint256 newPeriod) external returns (bool ok) {
         string memory sig = "setLockupPeriod(uint256)";
         (ok,) = address(pool).call(abi.encodeWithSignature(sig, newPeriod));
     }
 
-    function try_setStakingFee(address pool, uint256 newStakingFee) external returns(bool ok) {
+    function try_setStakingFee(address pool, uint256 newStakingFee) external returns (bool ok) {
         string memory sig = "setStakingFee(uint256)";
         (ok,) = address(pool).call(abi.encodeWithSignature(sig, newStakingFee));
     }
 
-    function try_triggerDefault(address pool, address loan, address dlFactory) external returns(bool ok) {
+    function try_triggerDefault(address pool, address loan, address dlFactory) external returns (bool ok) {
         string memory sig = "triggerDefault(address,address)";
         (ok,) = address(pool).call(abi.encodeWithSignature(sig, loan, dlFactory));
     }
 
-    function try_setOpenToPublic(address pool, bool open) external returns(bool ok) {
+    function try_setOpenToPublic(address pool, bool open) external returns (bool ok) {
         string memory sig = "setOpenToPublic(bool)";
         (ok,) = address(pool).call(abi.encodeWithSignature(sig, open));
     }
 
-    function try_openStakeLockerToPublic(address stakeLocker) external returns(bool ok) {
+    function try_openStakeLockerToPublic(address stakeLocker) external returns (bool ok) {
         string memory sig = "openStakeLockerToPublic()";
         (ok,) = address(stakeLocker).call(abi.encodeWithSignature(sig));
     }
 
-    function try_setAllowList(address pool, address user, bool status) external returns(bool ok) {
+    function try_setAllowList(address pool, address user, bool status) external returns (bool ok) {
         string memory sig = "setAllowList(address,bool)";
         (ok,) = address(pool).call(abi.encodeWithSignature(sig, user, status));
     }
 
-    function try_setAllowlist(address stakeLocker, address user, bool status) external returns(bool ok) {
+    function try_setAllowlist(address stakeLocker, address user, bool status) external returns (bool ok) {
         string memory sig = "setAllowlist(address,bool)";
         (ok,) = address(stakeLocker).call(abi.encodeWithSignature(sig, user, status));
     }
 
-    function try_setPoolAdmin(address pool, address newPoolAdmin, bool status) external returns(bool ok) {
+    function try_setPoolAdmin(address pool, address newPoolAdmin, bool status) external returns (bool ok) {
         string memory sig = "setPoolAdmin(address,bool)";
         (ok,) = address(pool).call(abi.encodeWithSignature(sig, newPoolAdmin, status));
     }
 
-    function try_pause(address target) external returns(bool ok) {
+    function try_pause(address target) external returns (bool ok) {
         string memory sig = "pause()";
         (ok,) = target.call(abi.encodeWithSignature(sig));
     }
 
-    function try_unpause(address target) external returns(bool ok) {
+    function try_unpause(address target) external returns (bool ok) {
         string memory sig = "unpause()";
         (ok,) = target.call(abi.encodeWithSignature(sig));
     }

--- a/contracts/test/user/Staker.sol
+++ b/contracts/test/user/Staker.sol
@@ -35,22 +35,22 @@ contract Staker {
     /*** TRY FUNCTIONS ***/
     /*********************/
 
-    function try_stake(address stakeLocker, uint256 amt) external returns(bool ok) {
+    function try_stake(address stakeLocker, uint256 amt) external returns (bool ok) {
         string memory sig = "stake(uint256)";
         (ok,) = address(stakeLocker).call(abi.encodeWithSignature(sig, amt));
     }
 
-    function try_unstake(address stakeLocker, uint256 amt) external returns(bool ok) {
+    function try_unstake(address stakeLocker, uint256 amt) external returns (bool ok) {
         string memory sig = "unstake(uint256)";
         (ok,) = address(stakeLocker).call(abi.encodeWithSignature(sig, amt));
     }
 
-    function try_transfer(address token, address dst, uint256 amt) external returns(bool ok) {
+    function try_transfer(address token, address dst, uint256 amt) external returns (bool ok) {
         string memory sig = "transfer(address,uint256)";
         (ok,) = address(token).call(abi.encodeWithSignature(sig, dst, amt));
     }
 
-    function try_transferFrom(address token, address from, address to, uint256 amt) external returns(bool ok) {
+    function try_transferFrom(address token, address from, address to, uint256 amt) external returns (bool ok) {
         string memory sig = "transferFrom(address,address,uint256)";
         (ok,) = address(token).call(abi.encodeWithSignature(sig, from, to, amt));
     }
@@ -65,7 +65,7 @@ contract Staker {
         (ok,) = stakeLocker.call(abi.encodeWithSignature(sig));
     }
 
-    function try_withdrawFunds(address stakeLocker) external returns(bool ok) {
+    function try_withdrawFunds(address stakeLocker) external returns (bool ok) {
         string memory sig = "withdrawFunds()";
         (ok,) = stakeLocker.call(abi.encodeWithSignature(sig));
     }

--- a/contracts/token/BasicFDT.sol
+++ b/contracts/token/BasicFDT.sol
@@ -29,14 +29,14 @@ abstract contract BasicFDT is IBaseFDT, ERC20 {
     /**
         @dev Distributes funds to token holders.
         @dev It reverts if the total supply of tokens is 0.
-        @dev It emits a `FundsDistributed` event if the amount of received ether is greater than 0.
-        @dev It emits a `PointsPerShareUpdated` event if the amount of received ether is greater than 0.
+        @dev It emits a `FundsDistributed` event if the amount of received funds is greater than 0.
+        @dev It emits a `PointsPerShareUpdated` event if the amount of received funds is greater than 0.
              About undistributed funds:
                 In each distribution, there is a small amount of funds which does not get distributed,
                    which is `(value  pointsMultiplier) % totalSupply()`.
                 With a well-chosen `pointsMultiplier`, the amount funds that are not getting distributed
                    in a distribution can be less than 1 (base unit).
-                We can actually keep track of the undistributed ether in a distribution
+                We can actually keep track of the undistributed funds in a distribution
                    and try to distribute it in the next distribution.
     */
     function _distributeFunds(uint256 value) internal {
@@ -51,7 +51,7 @@ abstract contract BasicFDT is IBaseFDT, ERC20 {
 
     /**
         @dev    Prepares funds withdrawal
-        @dev    It emits a `FundsWithdrawn` event if the amount of withdrawn ether is greater than 0.
+        @dev    It emits a `FundsWithdrawn` event if the amount of withdrawn funds is greater than 0.
         @return withdrawableDividend The amount of dividend funds that can be withdrawn.
     */
     function _prepareWithdraw() internal returns (uint256 withdrawableDividend) {

--- a/contracts/token/ExtendedFDT.sol
+++ b/contracts/token/ExtendedFDT.sol
@@ -184,7 +184,7 @@ abstract contract ExtendedFDT is BasicFDT {
     /**
         @dev Recognizes all recognizable losses for a user using loss accounting.
     */
-    function recognizeLosses() internal virtual returns (uint256 losses) { }
+    function _recognizeLosses() internal virtual returns (uint256 losses) { }
 
     /**
         @dev    Updates the current losses balance and returns the difference of new and previous losses balances.

--- a/contracts/token/PoolFDT.sol
+++ b/contracts/token/PoolFDT.sol
@@ -21,7 +21,7 @@ abstract contract PoolFDT is ExtendedFDT {
     /**
         @dev Realizes losses incurred to LPs.
     */
-    function recognizeLosses() internal override returns (uint256 losses) {
+    function _recognizeLosses() internal override returns (uint256 losses) {
         losses = _prepareLossesWithdraw();
 
         poolLosses = poolLosses.sub(losses);

--- a/contracts/token/StakeLockerFDT.sol
+++ b/contracts/token/StakeLockerFDT.sol
@@ -24,7 +24,7 @@ abstract contract StakeLockerFDT is ExtendedFDT {
         @dev    Updates loss accounting for msg.sender, recognizing losses.
         @return losses Amount to be subtracted from given withdraw amount.
     */
-    function recognizeLosses() internal override returns (uint256 losses) {
+    function _recognizeLosses() internal override returns (uint256 losses) {
         losses = _prepareLossesWithdraw();
 
         bptLosses = bptLosses.sub(losses);

--- a/contracts/token/interfaces/IExtendedFDT.sol
+++ b/contracts/token/interfaces/IExtendedFDT.sol
@@ -4,7 +4,7 @@ pragma solidity 0.6.11;
 import "./IBasicFDT.sol";
 
 interface IExtendedFDT is IBasicFDT {
-    function lossesPerShare() external view returns(uint256);
+    function lossesPerShare() external view returns (uint256);
 
     event LossesPerShareUpdated(uint256);
 

--- a/contracts/token/interfaces/IFDT.sol
+++ b/contracts/token/interfaces/IFDT.sol
@@ -4,7 +4,7 @@ pragma solidity 0.6.11;
 import "./IBasicFDT.sol";
 
 interface IFDT is IBasicFDT {
-    function fundsToken() external view returns(address);
+    function fundsToken() external view returns (address);
 
-    function fundsTokenBalance() external view returns(uint256);
+    function fundsTokenBalance() external view returns (uint256);
 }

--- a/contracts/token/interfaces/IStakeLockerFDT.sol
+++ b/contracts/token/interfaces/IStakeLockerFDT.sol
@@ -5,7 +5,7 @@ import "./IExtendedFDT.sol";
 import "./IFDT.sol";
 
 interface IStakeLockerFDT is IExtendedFDT, IFDT {
-    function bptLosses() external view returns(uint256);
+    function bptLosses() external view returns (uint256);
 
-    function lossesBalance() external view returns(uint256);
+    function lossesBalance() external view returns (uint256);
 }


### PR DESCRIPTION
# Description

Address Kurt's comments as seen [here](https://app.clubhouse.io/maplefinance/story/2092/maple-core-address-kurt-s-comments-in-chat) and cleans up some comment indentations.

# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog

- Address Kurt's comments in chat (https://app.clubhouse.io/maplefinance/story/2092/maple-core-address-kurt-s-comments-in-chat)
- Rename internal functions `_convertFromUsd`, `_recognizeLosses`, `_calcAllotment`
- Remove unused globals in LoanLib
- Set state mutability of of pure to `transferByCustodianChecks` and `increaseCustodyAllowanceChecks`
- Remove unused argument in `LoanLib.unwind`
- Normalized function `returns` formatting

## Function Signature Changes

## Features 

## Events

