### PR TITLE
refactor: reduce end-user gas costs with Pool

### DIFF
--- a/contracts/MapleGlobals.sol
+++ b/contracts/MapleGlobals.sol
@@ -426,6 +426,14 @@ contract MapleGlobals {
         return validCalcs[calc] && ICalc(calc).calcType() == calcType;
     }
 
+    /**
+        @dev    Returns the lpCooldownPeriod and lpWithdrawWindow.
+        @return lpCooldownPeriod and lpWithdrawWindow.
+    */
+    function getLpParameters() external view returns (uint256, uint256) {
+        return (lpCooldownPeriod, lpWithdrawWindow);
+    }
+
     /************************/
     /*** Helper Functions ***/
     /************************/

--- a/contracts/MapleGlobals.sol
+++ b/contracts/MapleGlobals.sol
@@ -430,7 +430,7 @@ contract MapleGlobals {
         @dev    Returns the lpCooldownPeriod and lpWithdrawWindow.
         @return lpCooldownPeriod and lpWithdrawWindow.
     */
-    function getLpParameters() external view returns (uint256, uint256) {
+    function getLpCooldownParams() external view returns (uint256, uint256) {
         return (lpCooldownPeriod, lpWithdrawWindow);
     }
 

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -441,10 +441,10 @@ contract Pool is PoolFDT {
 
         (uint256 lpCooldownPeriod, uint256 lpWithdrawWindow) = _globals(superFactory).getLpCooldownParams();
 
-        require(depositDate[from].add(lockupPeriod) <= block.timestamp,                         "P:FUNDS_LOCKED");                                   // Restrict transfer during lockup period
-        require(balanceOf(from).sub(wad) >= totalCustodyAllowance[from],                        "P:INSUF_TRANSFERABLE_BAL");                         // User can only transfer tokens that aren't custodied
-        require(block.timestamp > (withdrawCooldown[to] + lpCooldownPeriod + lpWithdrawWindow), "P:TO_NOT_ALLOWED");   // Recipient must not be currently withdrawing
-        require(recognizableLossesOf(from) == uint256(0),                                       "P:RECOG_LOSSES");                                   // If an LP has unrecognized losses, they must recognize losses through withdraw
+        require(depositDate[from].add(lockupPeriod) <= block.timestamp,                         "P:FUNDS_LOCKED");            // Restrict transfer during lockup period
+        require(balanceOf(from).sub(wad) >= totalCustodyAllowance[from],                        "P:INSUF_TRANSFERABLE_BAL");  // User can only transfer tokens that aren't custodied
+        require(block.timestamp > (withdrawCooldown[to] + lpCooldownPeriod + lpWithdrawWindow), "P:TO_NOT_ALLOWED");          // Recipient must not be currently withdrawing
+        require(recognizableLossesOf(from) == uint256(0),                                       "P:RECOG_LOSSES");            // If an LP has unrecognized losses, they must recognize losses through withdraw
 
         PoolLib.updateDepositDate(depositDate, balanceOf(to), wad, to);
         super._transfer(from, to, wad);
@@ -499,7 +499,7 @@ contract Pool is PoolFDT {
         uint256 oldAllowance = custodyAllowance[from][msg.sender];
         uint256 newAllowance = oldAllowance.sub(amount);
 
-        PoolLib.transferByCustodianChecks(from, to, amount, oldAllowance);
+        PoolLib.transferByCustodianChecks(from, to, amount);
 
         custodyAllowance[from][msg.sender] = newAllowance;
         totalCustodyAllowance[from]        = totalCustodyAllowance[from].sub(amount);

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -441,10 +441,10 @@ contract Pool is PoolFDT {
 
         (uint256 lpCooldownPeriod, uint256 lpWithdrawWindow) = _globals(superFactory).getLpCooldownParams();
 
-        require(depositDate[from].add(lockupPeriod) <= block.timestamp,  "P:FUNDS_LOCKED");                                   // Restrict transfer during lockup period
-        require(balanceOf(from).sub(wad) >= totalCustodyAllowance[from], "P:INSUF_TRANSFERABLE_BAL");                         // User can only transfer tokens that aren't custodied
+        require(depositDate[from].add(lockupPeriod) <= block.timestamp,                         "P:FUNDS_LOCKED");                                   // Restrict transfer during lockup period
+        require(balanceOf(from).sub(wad) >= totalCustodyAllowance[from],                        "P:INSUF_TRANSFERABLE_BAL");                         // User can only transfer tokens that aren't custodied
         require(block.timestamp > (withdrawCooldown[to] + lpCooldownPeriod + lpWithdrawWindow), "P:TO_NOT_ALLOWED");   // Recipient must not be currently withdrawing
-        require(recognizableLossesOf(from) == uint256(0),                "P:RECOG_LOSSES");                                   // If an LP has unrecognized losses, they must recognize losses through withdraw
+        require(recognizableLossesOf(from) == uint256(0),                                       "P:RECOG_LOSSES");                                   // If an LP has unrecognized losses, they must recognize losses through withdraw
 
         PoolLib.updateDepositDate(depositDate, balanceOf(to), wad, to);
         super._transfer(from, to, wad);

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -150,7 +150,7 @@ contract Pool is PoolFDT {
         _isValidDelegateAndProtocolNotPaused();
         _isValidState(State.Initialized);
         (,, bool stakeSufficient,,) = getInitialStakeRequirements();
-        require(stakeSufficient, "P:INSUFFICIENT_STAKE");
+        require(stakeSufficient, "P:INSUF_STAKE");
         poolState = State.Finalized;
         emit PoolStateChanged(poolState);
     }
@@ -307,7 +307,7 @@ contract Pool is PoolFDT {
     */
     function setLockupPeriod(uint256 newLockupPeriod) external {
         _isValidDelegateAndProtocolNotPaused();
-        require(newLockupPeriod <= lockupPeriod, "P:INVALID_VALUE");
+        require(newLockupPeriod <= lockupPeriod, "P:BAD_VALUE");
         lockupPeriod = newLockupPeriod;
         emit LockupPeriodSet(newLockupPeriod);
     }
@@ -319,7 +319,7 @@ contract Pool is PoolFDT {
     */
     function setStakingFee(uint256 newStakingFee) external {
         _isValidDelegateAndProtocolNotPaused();
-        require(newStakingFee.add(delegateFee) <= 10_000, "P:INVALID_FEE");
+        require(newStakingFee.add(delegateFee) <= 10_000, "P:BAD_FEE");
         stakingFee = newStakingFee;
         emit StakingFeeSet(newStakingFee);
     }
@@ -372,7 +372,7 @@ contract Pool is PoolFDT {
     function deposit(uint256 amt) external {
         _whenProtocolNotPaused();
         _isValidState(State.Finalized);
-        require(isDepositAllowed(amt), "P:DEPOSIT_NOT_ALLOWED");
+        require(isDepositAllowed(amt), "P:DEP_NOT_ALLOWED");
 
         withdrawCooldown[msg.sender] = uint256(0);  // Reset withdrawCooldown if LP had previously intended to withdraw
 
@@ -391,7 +391,7 @@ contract Pool is PoolFDT {
         @dev It emits a `Cooldown` event.
     **/
     function intendToWithdraw() external {
-        require(balanceOf(msg.sender) != uint256(0), "P:ZERO_BALANCE");
+        require(balanceOf(msg.sender) != uint256(0), "P:ZERO_BAL");
         withdrawCooldown[msg.sender] = block.timestamp;
         emit Cooldown(msg.sender, block.timestamp);
     }
@@ -443,7 +443,7 @@ contract Pool is PoolFDT {
 
         require(depositDate[from].add(lockupPeriod) <= block.timestamp,  "P:FUNDS_LOCKED");                                   // Restrict transfer during lockup period
         require(balanceOf(from).sub(wad) >= totalCustodyAllowance[from], "P:INSUF_TRANSFERABLE_BAL");                         // User can only transfer tokens that aren't custodied
-        require(block.timestamp > (withdrawCooldown[to] + lpCooldownPeriod + lpWithdrawWindow), "P:RECIPIENT_NOT_ALLOWED");   // Recipient must not be currently withdrawing
+        require(block.timestamp > (withdrawCooldown[to] + lpCooldownPeriod + lpWithdrawWindow), "P:TO_NOT_ALLOWED");   // Recipient must not be currently withdrawing
         require(recognizableLossesOf(from) == uint256(0),                "P:RECOG_LOSSES");                                   // If an LP has unrecognized losses, they must recognize losses through withdraw
 
         PoolLib.updateDepositDate(depositDate, balanceOf(to), wad, to);
@@ -614,14 +614,14 @@ contract Pool is PoolFDT {
         @param _state Enum of desired Pool state.
     */
     function _isValidState(State _state) internal view {
-        require(poolState == _state, "P:INVALID_STATE");
+        require(poolState == _state, "P:BAD_STATE");
     }
 
     /**
         @dev Checks that `msg.sender` is the Pool Delegate.
     */
     function _isValidDelegate() internal view {
-        require(msg.sender == poolDelegate, "P:NOT_DELEGATE");
+        require(msg.sender == poolDelegate, "P:NOT_DEL");
     }
 
     /**
@@ -652,7 +652,7 @@ contract Pool is PoolFDT {
         @dev Checks that `msg.sender` is the Pool Delegate or a Pool Admin.
     */
     function _isValidDelegateOrPoolAdmin() internal view {
-        require(msg.sender == poolDelegate || poolAdmins[msg.sender], "P:NOT_DELEGATE_OR_ADMIN");
+        require(msg.sender == poolDelegate || poolAdmins[msg.sender], "P:NOT_DEL_OR_ADMIN");
     }
 
     /**

--- a/contracts/interfaces/IMapleGlobals.sol
+++ b/contracts/interfaces/IMapleGlobals.sol
@@ -34,6 +34,8 @@ interface IMapleGlobals {
 
     function isValidCalc(address, uint8) external view returns (bool);
 
+    function getLpParameters() external view returns (uint256, uint256);
+
     function isValidLoanFactory(address) external view returns (bool);
 
     function isValidSubFactory(address, address, uint8) external view returns (bool);

--- a/contracts/interfaces/IMapleGlobals.sol
+++ b/contracts/interfaces/IMapleGlobals.sol
@@ -34,7 +34,7 @@ interface IMapleGlobals {
 
     function isValidCalc(address, uint8) external view returns (bool);
 
-    function getLpParameters() external view returns (uint256, uint256);
+    function getLpCooldownParams() external view returns (uint256, uint256);
 
     function isValidLoanFactory(address) external view returns (bool);
 

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -44,13 +44,15 @@ library PoolLib {
         uint256 stakingFee, 
         uint256 delegateFee
     ) external view {
+        IBPool stakePool = IBPool(stakeAsset);
+
         require(globals.isValidLiquidityAsset(liquidityAsset), "P:INVALID_LIQ_ASSET");
         require(stakingFee.add(delegateFee) <= 10_000,         "P:INVALID_FEES");
         require(
             globals.isValidBalancerPool(address(stakeAsset)) &&
-            IBPool(stakeAsset).isBound(globals.mpl())        && 
-            IBPool(stakeAsset).isBound(liquidityAsset)       &&
-            IBPool(stakeAsset).isFinalized(), 
+            stakePool.isBound(globals.mpl())                 && 
+            stakePool.isBound(liquidityAsset)                &&
+            stakePool.isFinalized(), 
             "P:INVALID_BALANCER_POOL"
         );
     }
@@ -440,7 +442,7 @@ library PoolLib {
         @param amt                    Amount to convert.
         @param liquidityAssetDecimals Liquidity asset decimal.
     */
-    function fromWad(uint256 amt, uint256 liquidityAssetDecimals) public pure returns (uint256) {
+    function fromWad(uint256 amt, uint256 liquidityAssetDecimals) external pure returns (uint256) {
         return amt.mul(10 ** liquidityAssetDecimals).div(WAD);
     }
 

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -22,9 +22,7 @@ library PoolLib {
     uint256 public constant WAD         = 10 ** 18;
     uint8   public constant DL_FACTORY  = 1;         // Factory type of `DebtLockerFactory`
 
-    event         LoanFunded(address indexed loan, address debtLocker, uint256 amountFunded);
-    event DepositDateUpdated(address indexed lp, uint256 depositDate);
-    event           Cooldown(address indexed lp, uint256 cooldown);
+    event LoanFunded(address indexed loan, address debtLocker, uint256 amountFunded);
 
     /***************************************/
     /*** Pool Delegate Utility Functions ***/
@@ -199,66 +197,6 @@ library PoolLib {
     /********************************************/
 
     /**
-        @dev   Update the effective deposit date based on how much new capital has been added.
-               If more capital is added, the depositDate moves closer to the current timestamp.
-        @dev   It emits a `DepositDateUpdated` event.
-        @param depositDate Weighted timestamp representing effective deposit date.
-        @param balance     Balance of PoolFDT tokens of user.
-        @param amt         Total deposit amount.
-        @param who         Address of user depositing.
-    */
-    function updateDepositDate(mapping(address => uint256) storage depositDate, uint256 balance, uint256 amt, address who) internal {
-        uint256 prevDate = depositDate[who];
-
-        // prevDate + (now - prevDate) * (amt / (balance + amt))
-        // NOTE: prevDate = 0 implies balance = 0, and equation reduces to now
-        uint256 newDate = (balance + amt) > 0
-            ? prevDate.add(block.timestamp.sub(prevDate).mul(amt).div(balance + amt))
-            : prevDate;
-
-        depositDate[who] = newDate;
-        emit DepositDateUpdated(who, newDate);
-    }
-
-    /**
-        @dev View function to indicate if `msg.sender` is within their withdraw window.
-    */
-    function isWithdrawAllowed(uint256 withdrawCooldown, IMapleGlobals globals) external view returns (bool) {
-        return (block.timestamp - (withdrawCooldown + globals.lpCooldownPeriod())) <= globals.lpWithdrawWindow();
-    }
-
-    /**
-        @dev View function to indicate if recipient is allowed to receive a transfer.
-             This is only possible if they have zero cooldown or they are passed their withdraw window.
-    */
-    function isReceiveAllowed(uint256 withdrawCooldown, IMapleGlobals globals) public view returns (bool) {
-        return block.timestamp > (withdrawCooldown + globals.lpCooldownPeriod() + globals.lpWithdrawWindow());
-    }
-
-    /**
-        @dev Performs all necessary checks for a `transfer` call.
-    */
-    function prepareTransfer(
-        mapping(address => uint256) storage withdrawCooldown,
-        mapping(address => uint256) storage depositDate,
-        uint256 totalCustodyAllowance,
-        uint256 fromBalance,
-        address from,
-        address to,
-        uint256 wad,
-        IMapleGlobals globals,
-        uint256 toBalance,
-        uint256 recognizableLosses,
-        uint256 lockupPeriod
-    ) external {
-        require(depositDate[from].add(lockupPeriod) <= block.timestamp, "P:FUNDS_LOCKED");              // Restrict transfer during lockup period
-        require(fromBalance.sub(wad) >= totalCustodyAllowance,          "P:INSUF_TRANSFERABLE_BAL");    // User can only transfer tokens that aren't custodied
-        require(isReceiveAllowed(withdrawCooldown[to], globals),        "P:RECIPIENT_NOT_ALLOWED");     // Recipient must not be currently withdrawing
-        require(recognizableLosses == uint256(0),                       "P:RECOG_LOSSES");              // If an LP has unrecognized losses, they must recognize losses through withdraw
-        updateDepositDate(depositDate, toBalance, wad, to);                                             // Update deposit date of recipient
-    }
-
-    /**
         @dev Performs all necessary checks for a `transferByCustodian` call.
         @dev From and to must always be equal.
     */
@@ -274,26 +212,6 @@ library PoolLib {
         require(custodian != address(0),     "P:INVALID_CUSTODIAN");
         require(amount    != uint256(0),     "P:INVALID_AMT");
         require(newTotalAllowance <= fdtBal, "P:INSUFFICIENT_BALANCE");
-    }
-
-    /**
-        @dev Activates the cooldown period to withdraw. It can't be called if the user is not an LP.
-        @dev It emits a `Cooldown` event.
-    */
-    function intendToWithdraw(mapping(address => uint256) storage withdrawCooldown, uint256 balance) external {
-        require(balance != uint256(0), "P:ZERO_BALANCE");
-        withdrawCooldown[msg.sender] = block.timestamp;
-        emit Cooldown(msg.sender, block.timestamp);
-    }
-
-    /**
-        @dev Cancel an initiated withdrawal.
-        @dev It emits a `Cooldown` event.
-    */
-    function cancelWithdraw(mapping(address => uint256) storage withdrawCooldown) external {
-        require(withdrawCooldown[msg.sender] != uint256(0), "P:NOT_WITHDRAWING");
-        withdrawCooldown[msg.sender] = uint256(0);
-        emit Cooldown(msg.sender, uint256(0));
     }
 
     /**********************************/

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -221,7 +221,7 @@ library PoolLib {
         @dev Performs all necessary checks for a `transferByCustodian` call.
         @dev From and to must always be equal.
     */
-    function transferByCustodianChecks(address from, address to, uint256 amount, uint256 custodyAllowance) external pure {
+    function transferByCustodianChecks(address from, address to, uint256 amount) external pure {
         require(to == from,                 "P:INVALID_RECEIVER");
         require(amount != uint256(0),       "P:INVALID_AMT");
     }

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -44,15 +44,15 @@ library PoolLib {
         uint256 stakingFee, 
         uint256 delegateFee
     ) external view {
-        IBPool stakePool = IBPool(stakeAsset);
+        IBPool bPool = IBPool(stakeAsset);
 
         require(globals.isValidLiquidityAsset(liquidityAsset), "P:INVALID_LIQ_ASSET");
         require(stakingFee.add(delegateFee) <= 10_000,         "P:INVALID_FEES");
         require(
             globals.isValidBalancerPool(address(stakeAsset)) &&
-            stakePool.isBound(globals.mpl())                 && 
-            stakePool.isBound(liquidityAsset)                &&
-            stakePool.isFinalized(), 
+            bPool.isBound(globals.mpl())                     && 
+            bPool.isBound(liquidityAsset)                    &&
+            bPool.isFinalized(), 
             "P:INVALID_BALANCER_POOL"
         );
     }


### PR DESCRIPTION
# Description

- getLpParameters() at MapleGLobals to get lpCooldownPeriod and lpWithdrawWindow in one call
- reduce the need to fetch globals via a call by keeping it as a state variable
- reduce external calls to PoolLib for compute that can be done much cheaper, and with less calldata, locally

# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog
## Function Signature Changes

## Features 

## Events

