### PR TITLE
refactor: Standardized ERC2258 with inheritance

### DIFF
--- a/contracts/MplRewards.sol
+++ b/contracts/MplRewards.sol
@@ -5,7 +5,7 @@ import "lib/openzeppelin-contracts/contracts/access/Ownable.sol";
 import "lib/openzeppelin-contracts/contracts/math/Math.sol";
 import "lib/openzeppelin-contracts/contracts/math/SafeMath.sol";
 import "lib/openzeppelin-contracts/contracts/token/ERC20/SafeERC20.sol";
-import "./interfaces/IERC2258.sol";
+import "./token/interfaces/IERC2258.sol";
 
 // https://docs.synthetix.io/contracts/source/contracts/stakingrewards
 /// @title MplRewards Synthetix farming contract fork for liquidity mining.

--- a/contracts/interfaces/ILoan.sol
+++ b/contracts/interfaces/ILoan.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity 0.6.11;
 
-import "../token/interfaces/IFDT.sol";
+import "../token/interfaces/ILoanFDT.sol";
 
-interface ILoan is IFDT {
+interface ILoan is ILoanFDT {
     
     // State Variables
     function liquidityAsset() external view returns (address);

--- a/contracts/interfaces/IPool.sol
+++ b/contracts/interfaces/IPool.sol
@@ -10,10 +10,6 @@ interface IPool is IPoolFDT {
 
     function deposit(uint256) external;
 
-    function increaseCustodyAllowance(address, uint256) external;
-
-    function transferByCustodian(address, address, uint256) external;
-
     function poolState() external view returns (uint256);
 
     function deactivate() external;

--- a/contracts/interfaces/IStakeLocker.sol
+++ b/contracts/interfaces/IStakeLocker.sol
@@ -38,10 +38,6 @@ interface IStakeLocker is IStakeLockerFDT {
 
     function cancelUnstake() external;
 
-    function increaseCustodyAllowance(address, uint256) external;
-
-    function transferByCustodian(address, address, uint256) external;
-
     function pause() external;
 
     function unpause() external;

--- a/contracts/library/PoolLib.sol
+++ b/contracts/library/PoolLib.sol
@@ -75,7 +75,7 @@ library PoolLib {
         address dlFactory,
         uint256 amt
     ) external {
-        IMapleGlobals globals = _globals(superFactory);
+        IMapleGlobals globals = IMapleGlobals(ILoanFactory(superFactory).globals());
         address loanFactory   = ILoan(loan).superFactory();
 
         // Auth checks
@@ -219,24 +219,6 @@ library PoolLib {
         emit DepositDateUpdated(who, newDate);
     }
 
-    /**
-        @dev Performs all necessary checks for a `transferByCustodian` call.
-        @dev From and to must always be equal.
-    */
-    function transferByCustodianChecks(address from, address to, uint256 amount) external pure {
-        require(to == from,                 "P:INVALID_RECEIVER");
-        require(amount != uint256(0),       "P:INVALID_AMT");
-    }
-
-    /**
-        @dev Performs all necessary checks for a `increaseCustodyAllowance` call
-    */
-    function increaseCustodyAllowanceChecks(address custodian, uint256 amount, uint256 newTotalAllowance, uint256 fdtBal) external pure {
-        require(custodian != address(0),     "P:INVALID_CUSTODIAN");
-        require(amount    != uint256(0),     "P:INVALID_AMT");
-        require(newTotalAllowance <= fdtBal, "P:INSUFFICIENT_BALANCE");
-    }
-
     /**********************************/
     /*** Governor Utility Functions ***/
     /**********************************/
@@ -260,7 +242,7 @@ library PoolLib {
     /**
         @dev Official balancer pool bdiv() function, does synthetic float with 10^-18 precision
     */
-    function bdiv(uint256 a, uint256 b) public pure returns (uint256) {
+    function bdiv(uint256 a, uint256 b) internal pure returns (uint256) {
         require(b != 0, "P:DIV_ZERO");
         uint256 c0 = a * WAD;
         require(a == 0 || c0 / a == WAD, "P:DIV_INTERNAL");  // bmul overflow
@@ -444,15 +426,6 @@ library PoolLib {
     */
     function fromWad(uint256 amt, uint256 liquidityAssetDecimals) external pure returns (uint256) {
         return amt.mul(10 ** liquidityAssetDecimals).div(WAD);
-    }
-
-    /** 
-        @dev    Internal helper function to return an interface of MapleGlobals.
-        @param  poolFactory Factory that deployed the Pool, stores MapleGlobals.
-        @return Interface of MapleGlobals.
-    */
-    function _globals(address poolFactory) internal view returns (IMapleGlobals) {
-        return IMapleGlobals(ILoanFactory(poolFactory).globals());
     }
 
     /** 

--- a/contracts/test/PoolCustodial.t.sol
+++ b/contracts/test/PoolCustodial.t.sol
@@ -14,7 +14,7 @@ contract PoolCustodialTest is TestUtil {
     uint256 liquidityLockerBal;  // Total liquidityAsset balance of LiquidityLocker
     uint256 fdtTotalSupply;      // PoolFDT total supply
     uint256 interestSum;         // FDT accounting of interst earned
-    uint256 poolLosses;          // FDT accounting of recognizable losses
+    uint256 lossesSum;           // FDT accounting of recognizable losses
 
     TestObj withdrawableFundsOf_fay;  // FDT accounting of interest
     TestObj withdrawableFundsOf_fez;  // FDT accounting of interest
@@ -54,7 +54,7 @@ contract PoolCustodialTest is TestUtil {
         liquidityLockerBal = usdc.balanceOf(pool.liquidityLocker());
         fdtTotalSupply     = pool.totalSupply();
         interestSum        = pool.interestSum();
-        poolLosses         = pool.poolLosses();
+        lossesSum          = pool.lossesSum();
 
         withdrawableFundsOf_fay.post = pool.withdrawableFundsOf(address(fay));
         withdrawableFundsOf_fez.post = pool.withdrawableFundsOf(address(fez));

--- a/contracts/token/BasicFDT.sol
+++ b/contracts/token/BasicFDT.sol
@@ -10,6 +10,7 @@ import "../math/SafeMathInt.sol";
 
 /// @title BasicFDT implements base level FDT functionality for accounting for revenues
 abstract contract BasicFDT is IBaseFDT, ERC20 {
+    
     using SafeMath       for uint256;
     using SafeMathUint   for uint256;
     using SignedSafeMath for  int256;

--- a/contracts/token/ERC2258.sol
+++ b/contracts/token/ERC2258.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity 0.6.11;
+
+import "lib/openzeppelin-contracts/contracts/math/SafeMath.sol";
+import "lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+
+/// @title ERC2258 implements base level ERC2258 functionality for custodial functionality
+abstract contract ERC2258 is ERC20 {
+
+    using SafeMath for uint256;
+
+    mapping(address => mapping(address => uint256)) public custodyAllowance;           // Amount of funds that are "locked" at a certain address
+    mapping(address => uint256)                     public totalCustodyAllowance;      // Total amount of funds that are "locked" for a given user, cannot be greater than balance
+
+    event         CustodyTransfer(address indexed custodian, address indexed from, address indexed to, uint256 amount);
+    event CustodyAllowanceChanged(address indexed tokenHolder, address indexed custodian, uint256 oldAllowance, uint256 newAllowance);
+
+    /**
+        @dev   Increase the custody allowance for a given `custodian` corresponding to `msg.sender`.
+        @dev   It emits a `CustodyAllowanceChanged` event.
+        @param custodian Address which will act as custodian of a given `amount` for a tokenHolder.
+        @param amount    Number of FDTs custodied by the custodian.
+    */
+    function increaseCustodyAllowance(address custodian, uint256 amount) external virtual {
+        uint256 oldAllowance      = custodyAllowance[msg.sender][custodian];
+        uint256 newAllowance      = oldAllowance.add(amount);
+        uint256 newTotalAllowance = totalCustodyAllowance[msg.sender].add(amount);
+
+        require(custodian != address(0),                     "ERC2258:BAD_CUST");
+        require(amount    != uint256(0),                     "ERC2258:BAD_AMT");
+        require(newTotalAllowance <= balanceOf(msg.sender),  "ERC2258:INSUF_BAL");
+        
+        custodyAllowance[msg.sender][custodian] = newAllowance;
+        totalCustodyAllowance[msg.sender]       = newTotalAllowance;
+
+        emit CustodyAllowanceChanged(msg.sender, custodian, oldAllowance, newAllowance);
+    }
+
+    /**
+        @dev   `from` and `to` should always be equal in this implementation.
+        @dev   This means that the custodian can only decrease their own allowance and unlock funds for the original owner.
+        @dev   It emits a `CustodyTransfer` event.
+        @dev   It emits a `CustodyAllowanceChanged` event.
+        @param from   Address which holds the funds.
+        @param to     Address which will be the new owner of the `amount` of funds transferred.
+        @param amount Amount of funds to be transferred.
+    */
+    function transferByCustodian(address from, address to, uint256 amount) external virtual {
+        uint256 oldAllowance = custodyAllowance[from][msg.sender];
+        uint256 newAllowance = oldAllowance.sub(amount);
+
+        require(to == from,             "ERC2258:BAD_REC");
+        require(amount != uint256(0),   "ERC2258:BAD_AMT");
+
+        custodyAllowance[from][msg.sender] = newAllowance;
+        totalCustodyAllowance[from]        = totalCustodyAllowance[from].sub(amount);
+
+        emit CustodyTransfer(msg.sender, from, to, amount);
+        emit CustodyAllowanceChanged(msg.sender, to, oldAllowance, newAllowance);
+    }
+}

--- a/contracts/token/ExtendedFDT.sol
+++ b/contracts/token/ExtendedFDT.sol
@@ -5,6 +5,7 @@ import "./BasicFDT.sol";
 
 /// @title ExtendedFDT implements FDT functionality for accounting for losses
 abstract contract ExtendedFDT is BasicFDT {
+    
     using SafeMath       for uint256;
     using SafeMathUint   for uint256;
     using SignedSafeMath for  int256;

--- a/contracts/token/LoanFDT.sol
+++ b/contracts/token/LoanFDT.sol
@@ -5,8 +5,9 @@ import "lib/openzeppelin-contracts/contracts/token/ERC20/SafeERC20.sol";
 
 import "./BasicFDT.sol";
 
-/// @title FDT inherits BasicFDT and uses the original ERC-2222 logic.
-abstract contract FDT is BasicFDT {
+/// @title LoanFDT inherits BasicFDT and uses the original ERC-2222 logic.
+abstract contract LoanFDT is BasicFDT {
+    
     using SafeMath       for uint256;
     using SafeMathUint   for uint256;
     using SignedSafeMath for  int256;
@@ -27,11 +28,11 @@ abstract contract FDT is BasicFDT {
     function withdrawFunds() public virtual override {
         uint256 withdrawableFunds = _prepareWithdraw();
 
-        if (withdrawableFunds > uint256(0)) {
-            fundsToken.safeTransfer(msg.sender, withdrawableFunds);
+        if (withdrawableFunds == uint256(0)) return;
 
-            _updateFundsTokenBalance();
-        }
+        fundsToken.safeTransfer(msg.sender, withdrawableFunds);
+
+        _updateFundsTokenBalance();
     }
 
     /**

--- a/contracts/token/PoolFDT.sol
+++ b/contracts/token/PoolFDT.sol
@@ -1,22 +1,50 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity 0.6.11;
 
+import "lib/openzeppelin-contracts/contracts/token/ERC20/SafeERC20.sol";
+
 import "./ExtendedFDT.sol";
+import "./ERC2258.sol";
 
 /// @title PoolFDT inherits ExtendedFDT and accounts for gains/losses for Liquidity Providers.
-abstract contract PoolFDT is ExtendedFDT {
+abstract contract PoolFDT is ExtendedFDT, ERC2258 {
+    
     using SafeMath       for uint256;
     using SafeMathUint   for uint256;
     using SignedSafeMath for  int256;
     using SafeMathInt    for  int256;
+    using SafeERC20      for  IERC20;
 
-    uint256 public interestSum;  // Sum of all withdrawable interest
-    uint256 public poolLosses;   // Sum of all unrecognized losses
+    IERC20 public fundsToken;
 
+    uint256 public lossesSum;      // Sum of all unrecognized losses
+    uint256 public lossesBalance;  // The amount of losses present and accounted for in this contract.
+
+    uint256 public interestSum;      // Sum of all withdrawable interest
     uint256 public interestBalance;  // The amount of earned interest present and accounted for in this contract.
-    uint256 public lossesBalance;    // The amount of losses present and accounted for in this contract.
 
     constructor(string memory name, string memory symbol) ExtendedFDT(name, symbol) public { }
+
+    /**
+        @dev {ExtendedFDT-_burn}.
+    */
+    function _burn(address account, uint256 value) internal virtual override(ExtendedFDT, ERC20) {
+        super._burn(account, value);
+    }
+
+    /**
+        @dev {ExtendedFDT-_mint}.
+    */
+    function _mint(address account, uint256 value) internal virtual override(ExtendedFDT, ERC20) {
+        super._mint(account, value);
+    }
+
+    /**
+        @dev {ExtendedFDT-_transfer}.
+    */
+    function _transfer(address from, address to, uint256 value) internal virtual override(ExtendedFDT, ERC20) {
+        super._transfer(from, to, value);
+    }
 
     /**
         @dev Realizes losses incurred to LPs.
@@ -24,7 +52,7 @@ abstract contract PoolFDT is ExtendedFDT {
     function _recognizeLosses() internal override returns (uint256 losses) {
         losses = _prepareLossesWithdraw();
 
-        poolLosses = poolLosses.sub(losses);
+        lossesSum = lossesSum.sub(losses);
 
         _updateLossesBalance();
     }
@@ -36,9 +64,24 @@ abstract contract PoolFDT is ExtendedFDT {
     function _updateLossesBalance() internal override returns (int256) {
         uint256 _prevLossesTokenBalance = lossesBalance;
 
-        lossesBalance = poolLosses;
+        lossesBalance = lossesSum;
 
         return int256(lossesBalance).sub(int256(_prevLossesTokenBalance));
+    }
+
+    /**
+        @dev Withdraws all available funds for a token holder.
+    */
+    function withdrawFunds() public virtual override {
+        uint256 withdrawableFunds = _prepareWithdraw();
+
+        if (withdrawableFunds == uint256(0)) return;
+
+        fundsToken.safeTransfer(msg.sender, withdrawableFunds);
+
+        interestSum = interestSum.sub(withdrawableFunds);
+
+        _updateFundsTokenBalance();
     }
 
     /**

--- a/contracts/token/StakeLockerFDT.sol
+++ b/contracts/token/StakeLockerFDT.sol
@@ -1,23 +1,50 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity 0.6.11;
 
-import "./ExtendedFDT.sol";
+import "lib/openzeppelin-contracts/contracts/token/ERC20/SafeERC20.sol";
 
-/// @title PoolFDT inherits ExtendedFDT and accounts for gains/losses for Stakers.
-abstract contract StakeLockerFDT is ExtendedFDT {
+import "./ExtendedFDT.sol";
+import "./ERC2258.sol";
+
+/// @title StakeLockerFDT inherits ExtendedFDT and accounts for gains/losses for Stakers.
+abstract contract StakeLockerFDT is ExtendedFDT, ERC2258 {
+    
     using SafeMath       for uint256;
     using SafeMathUint   for uint256;
     using SignedSafeMath for  int256;
     using SafeMathInt    for  int256;
+    using SafeERC20      for  IERC20;
 
     IERC20 public immutable fundsToken;
 
-    uint256 public bptLosses;          // Sum of all unrecognized losses
-    uint256 public lossesBalance;      // The amount of losses present and accounted for in this contract.
+    uint256 public lossesSum;      // Sum of all unrecognized losses
+    uint256 public lossesBalance;  // The amount of losses present and accounted for in this contract.
+
     uint256 public fundsTokenBalance;  // The amount of fundsToken (liquidityAsset) currently present and accounted for in this contract.
 
     constructor(string memory name, string memory symbol, address _fundsToken) ExtendedFDT(name, symbol) public {
         fundsToken = IERC20(_fundsToken);
+    }
+
+    /**
+        @dev   {ExtendedFDT-_burn}.
+    */
+    function _burn(address account, uint256 value) internal virtual override(ExtendedFDT, ERC20) {
+        super._burn(account, value);
+    }
+
+    /**
+        @dev   {ExtendedFDT-_mint}.
+    */
+    function _mint(address account, uint256 value) internal virtual override(ExtendedFDT, ERC20) {
+        super._mint(account, value);
+    }
+
+    /**
+        @dev   {ExtendedFDT-_transfer}.
+    */
+    function _transfer(address from, address to, uint256 value) internal virtual override(ExtendedFDT, ERC20) {
+        super._transfer(from, to, value);
     }
 
     /**
@@ -27,7 +54,7 @@ abstract contract StakeLockerFDT is ExtendedFDT {
     function _recognizeLosses() internal override returns (uint256 losses) {
         losses = _prepareLossesWithdraw();
 
-        bptLosses = bptLosses.sub(losses);
+        lossesSum = lossesSum.sub(losses);
 
         _updateLossesBalance();
     }
@@ -39,9 +66,22 @@ abstract contract StakeLockerFDT is ExtendedFDT {
     function _updateLossesBalance() internal override returns (int256) {
         uint256 _prevLossesTokenBalance = lossesBalance;
 
-        lossesBalance = bptLosses;
+        lossesBalance = lossesSum;
 
         return int256(lossesBalance).sub(int256(_prevLossesTokenBalance));
+    }
+
+    /**
+        @dev Withdraws all available funds for a token holder.
+    */
+    function withdrawFunds() public virtual override {
+        uint256 withdrawableFunds = _prepareWithdraw();
+
+        if (withdrawableFunds == uint256(0)) return;
+
+        fundsToken.safeTransfer(msg.sender, withdrawableFunds);
+
+        _updateFundsTokenBalance();
     }
 
     /**

--- a/contracts/token/interfaces/IERC2258.sol
+++ b/contracts/token/interfaces/IERC2258.sol
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity 0.6.11;
 
-interface IERC2258 {
+import "lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 
-    // Increase the custody limit of a custodian either directly or via signed authorisation
+interface IERC2258 is IERC20 {
+
+    // Increase the custody limit of a custodian directly 
     function increaseCustodyAllowance(address custodian, uint256 amount) external;
 
     // Query individual custody limit and total custody limit across all custodians

--- a/contracts/token/interfaces/IExtendedFDT.sol
+++ b/contracts/token/interfaces/IExtendedFDT.sol
@@ -6,14 +6,6 @@ import "./IBasicFDT.sol";
 interface IExtendedFDT is IBasicFDT {
     function lossesPerShare() external view returns (uint256);
 
-    event LossesPerShareUpdated(uint256);
-
-    event LossesCorrectionUpdated(address indexed, int256);
-
-    event LossesDistributed(address indexed, uint256);
-
-    event LossesRecognized(address indexed, uint256, uint256);
-
     function recognizableLossesOf(address) external view returns (uint256);
 
     function recognizedLossesOf(address) external view returns (uint256);
@@ -21,4 +13,12 @@ interface IExtendedFDT is IBasicFDT {
     function accumulativeLossesOf(address) external view returns (uint256);
 
     function updateLossesReceived() external;
+
+    event LossesPerShareUpdated(uint256);
+
+    event LossesCorrectionUpdated(address indexed, int256);
+
+    event LossesDistributed(address indexed, uint256);
+
+    event LossesRecognized(address indexed, uint256, uint256);
 }

--- a/contracts/token/interfaces/ILoanFDT.sol
+++ b/contracts/token/interfaces/ILoanFDT.sol
@@ -3,7 +3,7 @@ pragma solidity 0.6.11;
 
 import "./IBasicFDT.sol";
 
-interface IFDT is IBasicFDT {
+interface ILoanFDT is IBasicFDT {
     function fundsToken() external view returns (address);
 
     function fundsTokenBalance() external view returns (uint256);

--- a/contracts/token/interfaces/IPoolFDT.sol
+++ b/contracts/token/interfaces/IPoolFDT.sol
@@ -2,11 +2,12 @@
 pragma solidity 0.6.11;
 
 import "./IExtendedFDT.sol";
+import "./IERC2258.sol";
 
-interface IPoolFDT is IExtendedFDT {
+interface IPoolFDT is IExtendedFDT, IERC2258 {
     function interestSum() external view returns (uint256);
 
-    function poolLosses() external view returns (uint256);
+    function lossesSum() external view returns (uint256);
 
     function interestBalance() external view returns (uint256);
 

--- a/contracts/token/interfaces/IStakeLockerFDT.sol
+++ b/contracts/token/interfaces/IStakeLockerFDT.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.6.11;
 
 import "./IExtendedFDT.sol";
-import "./IFDT.sol";
+import "./IERC2258.sol";
 
-interface IStakeLockerFDT is IExtendedFDT, IFDT {
-    function bptLosses() external view returns (uint256);
+interface IStakeLockerFDT is IExtendedFDT, IERC2258 {
+    function lossesSum() external view returns (uint256);
 
     function lossesBalance() external view returns (uint256);
 }


### PR DESCRIPTION
# Description

- Standardized `LoanFDT`, `PoolFDT`, `StakeLockerFDT`
- Normalized `Loan`, `Pool`, and `StakeLocker` `FDT` and `ERC2258` functionality

# Integrations Checklist

- [X] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog

- Renamed incorrectly named `FDT` contract and `IFDT` interface to `LoanFDT` and `ILoanFDT` respectively
- Emitted a missing `BalanceUpdated` event in `Loan.withdrawFunds`
- Created a generic `ERC2258` abstraction/implementation from the existing (and duplicated) code
- Moved `ERC2258` interface to token directory
- Renamed non-generic `PoolFDT.poolLosses` to generic `ERC2258` `PoolFDT.lossesSum`
- Renamed non-generic `StakeLocker.bptLosses` to generic `ERC2258` `StakeLocker.lossesSum`
- Replaced `ILiquidityLocker(liquidityLocker).transfer(to, value)` in `Pool` with more generic `fundsToken.safeTransfer(to, value)`, given `Pool` is a `PoolFDT`
- Reduced the length of some `Pool` error messages
- Put reused `Pool` code into a new internal `_canWithdraw` function
- Removed `withdrawFunds` from `Loan`, `Pool`, and `StakeLocker` as they are now defined in `LoanFDT`, `PoolFDT`, and `StakeLockerFDT` respectively, making it much easier to see the inheritance and similarities/differences
- `increaseCustodyAllowance` and `transferByCustodian` in `Loan`, `Pool`, and `StakeLocker` now simply implemented once in the `ERC2258` inherited contract
- Similarly, `increaseCustodyAllowanceChecks` and `transferByCustodianChecks` are inline in the above functions, respectively
- Slight reduction in gas by skipping the need for a `_globals` function in `PoolLib`, as it was only used once.
- Slight reduction in gas by making `PoolLib.bdiv` internal.

## Function Signature Changes

## Features 

## Events

