### PR TITLE
chore: Post-C4 Re-review Changes (SC-2103)

### DIFF
--- a/contracts/Loan.sol
+++ b/contracts/Loan.sol
@@ -172,7 +172,7 @@ contract Loan is LoanFDT, Pausable {
 
     /**
         @dev   Drawdown funding from FundingLocker, post collateral, and transition loanState from `Ready` to `Active`. Only the Loan Borrower can call this function.
-        @dev   It emits four `BalanceUpdated` event.
+        @dev   It emits four `BalanceUpdated` events.
         @dev   It emits a `LoanStateChanged` event.
         @dev   It emits a `Drawdown` event.
         @param amt Amount of liquidityAsset borrower draws down, remainder is returned to Loan where it can be claimed back by LoanFDT holders.

--- a/contracts/LoanFactory.sol
+++ b/contracts/LoanFactory.sol
@@ -57,11 +57,11 @@ contract LoanFactory is Pausable {
     /**
         @dev    Create a new Loan.
         @dev    It emits a `LoanCreated` event.
-        @param  liquidityAsset  Asset the loan will raise funding in
-        @param  collateralAsset Asset the loan will use as collateral
-        @param  flFactory       The factory to instantiate a FundingLocker from
-        @param  clFactory       The factory to instantiate a CollateralLocker from
-        @param  specs           Contains specifications for this loan
+        @param  liquidityAsset  Asset the loan will raise funding in.
+        @param  collateralAsset Asset the loan will use as collateral.
+        @param  flFactory       The factory to instantiate a FundingLocker from.
+        @param  clFactory       The factory to instantiate a CollateralLocker from.
+        @param  specs           Contains specifications for this loan.
                                     specs[0] = apr
                                     specs[1] = termDays
                                     specs[2] = paymentIntervalDays

--- a/contracts/MapleTreasury.sol
+++ b/contracts/MapleTreasury.sol
@@ -66,8 +66,8 @@ contract MapleTreasury {
     /**
         @dev   Reclaim treasury funds to the MapleDAO address. Only the Governor can call this function.
         @dev   It emits a `ERC20Reclaimed` event.
-        @param asset  Address of the token that need to be reclaimed from the treasury contract,
-        @param amount Amount to withdraw,
+        @param asset  Address of the token that need to be reclaimed from the treasury contract.
+        @param amount Amount to withdraw.
     */
     function reclaimERC20(address asset, uint256 amount) isGovernor external {
         IERC20(asset).safeTransfer(msg.sender, amount);

--- a/contracts/MplRewards.sol
+++ b/contracts/MplRewards.sol
@@ -33,9 +33,9 @@ contract MplRewards is Ownable {
     mapping(address => uint256) private _balances;
 
     event            RewardAdded(uint256 reward);
-    event                 Staked(address indexed user, uint256 amount);
-    event              Withdrawn(address indexed user, uint256 amount);
-    event             RewardPaid(address indexed user, uint256 reward);
+    event                 Staked(address indexed account, uint256 amount);
+    event              Withdrawn(address indexed account, uint256 amount);
+    event             RewardPaid(address indexed account, uint256 reward);
     event RewardsDurationUpdated(uint256 newDuration);
     event              Recovered(address token, uint256 amount);
     event           PauseChanged(bool isPaused);
@@ -173,7 +173,7 @@ contract MplRewards is Ownable {
     }
 
     /**
-        @dev Added to support recovering tokens unintentionally sent to this contract by users.
+        @dev Added to support recovering tokens unintentionally sent to this contract.
              Only the contract Owner may call this.
         @dev It emits a `Recovered` event.
     */

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -415,7 +415,7 @@ contract Pool is PoolFDT {
         @param wad     The amount to withdraw.
     */
     function _canWithdraw(address account, uint256 wad) internal view {
-        require(depositDate[account].add(lockupPeriod) <= block.timestamp,     "P:FUNDS_LOCKED");     // Restrict transfer during lockup period
+        require(depositDate[account].add(lockupPeriod) <= block.timestamp,     "P:FUNDS_LOCKED");     // Restrict withdrawal during lockup period
         require(balanceOf(account).sub(wad) >= totalCustodyAllowance[account], "P:INSUF_TRANS_BAL");  // Account can only withdraw tokens that aren't custodied
     }
 
@@ -454,8 +454,8 @@ contract Pool is PoolFDT {
         (uint256 lpCooldownPeriod, uint256 lpWithdrawWindow) = _globals(superFactory).getLpCooldownParams();
 
         _canWithdraw(from, wad);
-        require(block.timestamp > (withdrawCooldown[to] + lpCooldownPeriod + lpWithdrawWindow), "P:TO_NOT_ALLOWED");   // Recipient must not be currently withdrawing
-        require(recognizableLossesOf(from) == uint256(0),                                       "P:RECOG_LOSSES");     // If an LP has unrecognized losses, they must recognize losses through withdraw
+        require(block.timestamp > (withdrawCooldown[to] + lpCooldownPeriod + lpWithdrawWindow), "P:TO_NOT_ALLOWED");  // Recipient must not be currently withdrawing
+        require(recognizableLossesOf(from) == uint256(0),                                       "P:RECOG_LOSSES");    // If an LP has unrecognized losses, they must recognize losses through withdraw
 
         PoolLib.updateDepositDate(depositDate, balanceOf(to), wad, to);
         super._transfer(from, to, wad);

--- a/contracts/Pool.sol
+++ b/contracts/Pool.sol
@@ -43,7 +43,7 @@ contract Pool is PoolFDT {
 
     uint256 public principalOut;  // Sum of all outstanding principal on Loans
     uint256 public liquidityCap;  // Amount of liquidity tokens accepted by the Pool
-    uint256 public lockupPeriod;  // Period of time from a user's depositDate that they cannot withdraw any funds
+    uint256 public lockupPeriod;  // Period of time from an account's depositDate that they cannot withdraw any funds
 
     bool public openToPublic;  // Boolean opening Pool to public for LP deposits
 
@@ -52,26 +52,27 @@ contract Pool is PoolFDT {
 
     mapping(address => uint256)                     public depositDate;                // Used for withdraw penalty calculation
     mapping(address => mapping(address => address)) public debtLockers;                // Address of the `DebtLocker` contract corresponds to [Loan][DebtLockerFactory].
-    mapping(address => bool)                        public poolAdmins;                 // Pool Admin addresses who have permission to do certain operations in case of disaster mgt.
+    mapping(address => bool)                        public poolAdmins;                 // Pool Admin addresses that have permission to do certain operations in case of disaster mgt.
     mapping(address => bool)                        public allowedLiquidityProviders;  // Map that contains the list of address to enjoy the early access of the pool.
     mapping(address => uint256)                     public withdrawCooldown;           // Timestamp of when LP calls `intendToWithdraw()`
     mapping(address => mapping(address => uint256)) public custodyAllowance;           // Amount of PoolFDTs that are "locked" at a certain address
-    mapping(address => uint256)                     public totalCustodyAllowance;      // Total amount of PoolFDTs that are "locked" for a given user, cannot be greater than balance
+    mapping(address => uint256)                     public totalCustodyAllowance;      // Total amount of PoolFDTs that are "locked" for a given account, cannot be greater than balance
 
-    event              LoanFunded(address indexed loan, address debtLocker, uint256 amountFunded);
-    event                   Claim(address indexed loan, uint256 interest, uint256 principal, uint256 fee, uint256 stakeLockerFee, uint256 poolDelegateFee);
-    event          BalanceUpdated(address indexed who, address indexed token, uint256 balance);
-    event         CustodyTransfer(address indexed custodian, address indexed from, address indexed to, uint256 amount);
-    event CustodyAllowanceChanged(address indexed tokenHolder, address indexed custodian, uint256 oldAllowance, uint256 newAllowance);
-    event         LPStatusChanged(address indexed user, bool status);
-    event         LiquidityCapSet(uint256 newLiquidityCap);
-    event         LockupPeriodSet(uint256 newLockupPeriod);
-    event           StakingFeeSet(uint256 newStakingFee);
-    event        PoolStateChanged(State state);
-    event                Cooldown(address indexed lp, uint256 cooldown);
-    event      PoolOpenedToPublic(bool isOpen);
-    event            PoolAdminSet(address poolAdmin, bool allowed);
-    event      DepositDateUpdated(address indexed lp, uint256 depositDate);
+    event                   LoanFunded(address indexed loan, address debtLocker, uint256 amountFunded);
+    event                        Claim(address indexed loan, uint256 interest, uint256 principal, uint256 fee, uint256 stakeLockerPortion, uint256 poolDelegatePortion);
+    event               BalanceUpdated(address indexed account, address indexed token, uint256 balance);
+    event              CustodyTransfer(address indexed custodian, address indexed from, address indexed to, uint256 amount);
+    event      CustodyAllowanceChanged(address indexed account, address indexed custodian, uint256 oldAllowance, uint256 newAllowance);
+    event              LPStatusChanged(address indexed account, bool status);
+    event              LiquidityCapSet(uint256 newLiquidityCap);
+    event              LockupPeriodSet(uint256 newLockupPeriod);
+    event                StakingFeeSet(uint256 newStakingFee);
+    event             PoolStateChanged(State state);
+    event                     Cooldown(address indexed lp, uint256 cooldown);
+    event           PoolOpenedToPublic(bool isOpen);
+    event                 PoolAdminSet(address poolAdmin, bool allowed);
+    event           DepositDateUpdated(address indexed lp, uint256 depositDate);
+    event TotalCustodyAllowanceUpdated(address indexed account, uint256 newTotalAllowance);
     
     event DefaultSuffered(
         address indexed loan,
@@ -157,6 +158,7 @@ contract Pool is PoolFDT {
 
     /**
         @dev   Fund a loan for amt, utilize the supplied dlFactory for debt lockers. Only the Pool Delegate can call this function.
+        @dev   It emits a `LoanFunded` event.
         @dev   It emits a `BalanceUpdated` event.
         @param loan      Address of the loan to fund.
         @param dlFactory The DebtLockerFactory to utilize.
@@ -325,15 +327,15 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev   Update user status on Pool allowlist. Only the Pool Delegate can call this function.
+        @dev   Update account status on Pool allowlist. Only the Pool Delegate can call this function.
         @dev   It emits an `LPStatusChanged` event.
-        @param user   The address to set status for.
-        @param status The status of user on allowlist.
+        @param account The address to set status for.
+        @param status  The status of an account on allowlist.
     */
-    function setAllowList(address user, bool status) external {
+    function setAllowList(address account, bool status) external {
         _isValidDelegateAndProtocolNotPaused();
-        allowedLiquidityProviders[user] = status;
-        emit LPStatusChanged(user, status);
+        allowedLiquidityProviders[account] = status;
+        emit LPStatusChanged(account, status);
     }
 
     /**
@@ -365,9 +367,10 @@ contract Pool is PoolFDT {
 
     /**
         @dev   Liquidity providers can deposit liquidityAsset into the LiquidityLocker, minting FDTs.
+        @dev   It emits a `DepositDateUpdated` event.
         @dev   It emits a `BalanceUpdated` event.
         @dev   It emits a `Cooldown` event.
-        @param amt Amount of liquidityAsset to deposit
+        @param amt Amount of liquidityAsset to deposit.
     */
     function deposit(uint256 amt) external {
         _whenProtocolNotPaused();
@@ -387,7 +390,7 @@ contract Pool is PoolFDT {
     }
 
     /**
-        @dev Activates the cooldown period to withdraw. It can't be called if the user is not providing liquidity.
+        @dev Activates the cooldown period to withdraw. It can't be called if the account is not providing liquidity.
         @dev It emits a `Cooldown` event.
     **/
     function intendToWithdraw() external {
@@ -407,8 +410,18 @@ contract Pool is PoolFDT {
     }
 
     /**
+        @dev   Checks that the account can withdraw an amount.
+        @param account The address of the account.
+        @param wad     The amount to withdraw.
+    */
+    function _canWithdraw(address account, uint256 wad) internal view {
+        require(depositDate[account].add(lockupPeriod) <= block.timestamp,     "P:FUNDS_LOCKED");     // Restrict transfer during lockup period
+        require(balanceOf(account).sub(wad) >= totalCustodyAllowance[account], "P:INSUF_TRANS_BAL");  // Account can only withdraw tokens that aren't custodied
+    }
+
+    /**
         @dev   Liquidity providers can withdraw liquidityAsset from the LiquidityLocker, burning PoolFDTs.
-        @dev   It emits a `BalanceUpdated` event.
+        @dev   It emits two `BalanceUpdated` event.
         @param amt Amount of liquidityAsset to withdraw.
     */
     function withdraw(uint256 amt) external {
@@ -416,9 +429,8 @@ contract Pool is PoolFDT {
         uint256 wad = _toWad(amt);
         (uint256 lpCooldownPeriod, uint256 lpWithdrawWindow) = _globals(superFactory).getLpCooldownParams();
 
-        require(balanceOf(msg.sender).sub(wad) >= totalCustodyAllowance[msg.sender],                       "P:INSUF_WITHDRAWABLE_BAL");  // User can only withdraw tokens that aren't custodied
+        _canWithdraw(msg.sender, wad);
         require((block.timestamp - (withdrawCooldown[msg.sender] + lpCooldownPeriod)) <= lpWithdrawWindow, "P:WITHDRAW_NOT_ALLOWED");
-        require(depositDate[msg.sender].add(lockupPeriod) <= block.timestamp,                              "P:FUNDS_LOCKED");
 
         _burn(msg.sender, wad);  // Burn the corresponding FDT balance
         withdrawFunds();         // Transfer full entitled interest, decrement `interestSum`
@@ -441,17 +453,16 @@ contract Pool is PoolFDT {
 
         (uint256 lpCooldownPeriod, uint256 lpWithdrawWindow) = _globals(superFactory).getLpCooldownParams();
 
-        require(depositDate[from].add(lockupPeriod) <= block.timestamp,                         "P:FUNDS_LOCKED");            // Restrict transfer during lockup period
-        require(balanceOf(from).sub(wad) >= totalCustodyAllowance[from],                        "P:INSUF_TRANSFERABLE_BAL");  // User can only transfer tokens that aren't custodied
-        require(block.timestamp > (withdrawCooldown[to] + lpCooldownPeriod + lpWithdrawWindow), "P:TO_NOT_ALLOWED");          // Recipient must not be currently withdrawing
-        require(recognizableLossesOf(from) == uint256(0),                                       "P:RECOG_LOSSES");            // If an LP has unrecognized losses, they must recognize losses through withdraw
+        _canWithdraw(from, wad);
+        require(block.timestamp > (withdrawCooldown[to] + lpCooldownPeriod + lpWithdrawWindow), "P:TO_NOT_ALLOWED");   // Recipient must not be currently withdrawing
+        require(recognizableLossesOf(from) == uint256(0),                                       "P:RECOG_LOSSES");     // If an LP has unrecognized losses, they must recognize losses through withdraw
 
         PoolLib.updateDepositDate(depositDate, balanceOf(to), wad, to);
         super._transfer(from, to, wad);
     }
 
     /**
-        @dev Withdraws all claimable interest from the `liquidityLocker` for a user using `interestSum` accounting.
+        @dev Withdraws all claimable interest from the `liquidityLocker` for an account using `interestSum` accounting.
         @dev It emits a `BalanceUpdated` event.
     */
     function withdrawFunds() public override {
@@ -471,7 +482,8 @@ contract Pool is PoolFDT {
     /**
         @dev   Increase the custody allowance for a given `custodian` corresponding to `msg.sender`.
         @dev   It emits a `CustodyAllowanceChanged` event.
-        @param custodian Address which will act as custodian of a given `amount` for a tokenHolder.
+        @dev   It emits a `TotalCustodyAllowanceUpdated` event.
+        @param custodian Address which will act as custodian of a given `amount` for an account.
         @param amount    Number of FDTs custodied by the custodian.
     */
     function increaseCustodyAllowance(address custodian, uint256 amount) external {
@@ -484,6 +496,7 @@ contract Pool is PoolFDT {
         custodyAllowance[msg.sender][custodian] = newAllowance;
         totalCustodyAllowance[msg.sender]       = newTotalAllowance;
         emit CustodyAllowanceChanged(msg.sender, custodian, oldAllowance, newAllowance);
+        emit TotalCustodyAllowanceUpdated(msg.sender, newTotalAllowance);
     }
 
     /**
@@ -491,6 +504,7 @@ contract Pool is PoolFDT {
         @dev   This means that the custodian can only decrease their own allowance and unlock funds for the original owner.
         @dev   It emits a `CustodyTransfer` event.
         @dev   It emits a `CustodyAllowanceChanged` event.
+        @dev   It emits a `TotalCustodyAllowanceUpdated` event.
         @param from   Address which holds to Pool FDTs.
         @param to     Address which will be the new owner of the `amount` of FDTs.
         @param amount Number of FDTs transferred.
@@ -502,9 +516,11 @@ contract Pool is PoolFDT {
         PoolLib.transferByCustodianChecks(from, to, amount);
 
         custodyAllowance[from][msg.sender] = newAllowance;
-        totalCustodyAllowance[from]        = totalCustodyAllowance[from].sub(amount);
+        uint256 newTotalAllowance          = totalCustodyAllowance[from].sub(amount);
+        totalCustodyAllowance[from]        = newTotalAllowance;
         emit CustodyTransfer(msg.sender, from, to, amount);
         emit CustodyAllowanceChanged(from, msg.sender, oldAllowance, newAllowance);
+        emit TotalCustodyAllowanceUpdated(msg.sender, newTotalAllowance);
     }
 
     /**************************/
@@ -525,11 +541,11 @@ contract Pool is PoolFDT {
 
     /**
         @dev    Calculates the value of BPT in units of liquidityAsset.
-        @param  _bPool          Address of Balancer pool
-        @param  _liquidityAsset Asset used by Pool for liquidity to fund loans
-        @param  _staker         Address that deposited BPTs to stakeLocker
-        @param  _stakeLocker    Escrows BPTs deposited by staker
-        @return USDC value of staker BPTs
+        @param  _bPool          Address of Balancer pool.
+        @param  _liquidityAsset Asset used by Pool for liquidity to fund loans.
+        @param  _staker         Address that deposited BPTs to stakeLocker.
+        @param  _stakeLocker    Escrows BPTs deposited by staker.
+        @return USDC value of staker BPTs.
     */
     function BPTVal(
         address _bPool,
@@ -542,7 +558,7 @@ contract Pool is PoolFDT {
 
     /**
         @dev   Checks that the given `depositAmt` is acceptable based on current liquidityCap.
-        @param depositAmt Amount of tokens (i.e liquidityAsset type) user is trying to deposit.
+        @param depositAmt Amount of tokens (i.e liquidityAsset type) the account is trying to deposit.
     */
     function isDepositAllowed(uint256 depositAmt) public view returns (bool) {
         return (openToPublic || allowedLiquidityProviders[msg.sender]) &&

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -312,7 +312,7 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     */
     function _transfer(address from, address to, uint256 wad) internal override canUnstake(from) {
         _whenProtocolNotPaused();
-        require(stakeDate[from].add(lockupPeriod) <= block.timestamp,    "SL:FUNDS_LOCKED");            // Restrict transfer during lockup period
+        require(stakeDate[from].add(lockupPeriod) <= block.timestamp,    "SL:FUNDS_LOCKED");            // Restrict withdrawal during lockup period
         require(balanceOf(from).sub(wad) >= totalCustodyAllowance[from], "SL:INSUF_TRANSFERABLE_BAL");  // Account can only transfer tokens that aren't custodied
         require(isReceiveAllowed(unstakeCooldown[to]),                   "SL:RECIPIENT_NOT_ALLOWED");   // Recipient must not be currently unstaking
         require(recognizableLossesOf(from) == uint256(0),                "SL:RECOG_LOSSES");            // If a staker has unrecognized losses, they must recognize losses through unstake

--- a/contracts/StakeLocker.sol
+++ b/contracts/StakeLocker.sol
@@ -30,20 +30,21 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     mapping(address => uint256)                     public unstakeCooldown;        // Timestamp of when staker called cooldown()
     mapping(address => bool)                        public allowed;                // Map address to allowed status
     mapping(address => mapping(address => uint256)) public custodyAllowance;       // Amount of StakeLockerFDTs that are "locked" at a certain address
-    mapping(address => uint256)                     public totalCustodyAllowance;  // Total amount of StakeLockerFDTs that are "locked" for a given user, cannot be greater than balance
+    mapping(address => uint256)                     public totalCustodyAllowance;  // Total amount of StakeLockerFDTs that are "locked" for a given account, cannot be greater than balance
 
     bool public openToPublic;  // Boolean opening StakeLocker to public for staking BPTs
 
-    event       StakeLockerOpened();
-    event          BalanceUpdated(address indexed who, address indexed token, uint256 balance);
-    event        AllowListUpdated(address indexed staker, bool status);
-    event        StakeDateUpdated(address indexed staker, uint256 stakeDate);
-    event     LockupPeriodUpdated(uint256 lockupPeriod);
-    event                Cooldown(address indexed staker, uint256 cooldown);
-    event                   Stake(uint256 amount, address indexed staker);
-    event                 Unstake(uint256 amount, address indexed staker);
-    event         CustodyTransfer(address indexed custodian, address indexed from, address indexed to, uint256 amount);
-    event CustodyAllowanceChanged(address indexed tokenHolder, address indexed custodian, uint256 oldAllowance, uint256 newAllowance);
+    event            StakeLockerOpened();
+    event               BalanceUpdated(address indexed account, address indexed token, uint256 balance);
+    event             AllowListUpdated(address indexed staker, bool status);
+    event             StakeDateUpdated(address indexed staker, uint256 stakeDate);
+    event          LockupPeriodUpdated(uint256 lockupPeriod);
+    event                     Cooldown(address indexed staker, uint256 cooldown);
+    event                        Stake(uint256 amount, address indexed staker);
+    event                      Unstake(uint256 amount, address indexed staker);
+    event              CustodyTransfer(address indexed custodian, address indexed from, address indexed to, uint256 amount);
+    event      CustodyAllowanceChanged(address indexed account, address indexed custodian, uint256 oldAllowance, uint256 newAllowance);
+    event TotalCustodyAllowanceUpdated(address indexed account, uint256 newTotalAllowance);
 
     constructor(
         address _stakeAsset,
@@ -61,14 +62,14 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     /*****************/
 
     /**
-        @dev Checks that a user can unstake given the following conditions:
-                 1. User is not Pool Delegate and the Pool is in Finalized state.
+        @dev Checks that an account can unstake given the following conditions:
+                 1. Account is not Pool Delegate and the Pool is in Finalized state.
                  2. The Pool is in Initialized or Deactivated state.
     */
     modifier canUnstake(address from) {
         IPool _pool = IPool(pool);
 
-        // Pool cannot be finalized, but if it is, user cannot be the Pool Delegate
+        // Pool cannot be finalized, but if it is, account cannot be the Pool Delegate
         require(!_pool.isPoolFinalized() || from != _pool.poolDelegate(), "SL:STAKE_LOCKED");
         _;
     }
@@ -154,10 +155,11 @@ contract StakeLocker is StakeLockerFDT, Pausable {
 
     /**
         @dev   Deposit amt of stakeAsset, mint FDTs to msg.sender.
+        @dev   It emits a `StakeDateUpdated` event.
         @dev   It emits a `Stake` event.
         @dev   It emits a `Cooldown` event.
         @dev   It emits a `BalanceUpdated` event.
-        @param amt Amount of stakeAsset (BPTs) to deposit
+        @param amt Amount of stakeAsset (BPTs) to deposit.
     */
     function stake(uint256 amt) whenNotPaused external {
         _whenProtocolNotPaused();
@@ -178,12 +180,12 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     /**
         @dev   Updates information used to calculate unstake delay.
         @dev   It emits a `StakeDateUpdated` event.
-        @param who Staker who deposited BPTs.
-        @param amt Amount of BPTs staker has deposited.
+        @param account Staker that deposited BPTs.
+        @param amt     Amount of BPTs staker has deposited.
     */
-    function _updateStakeDate(address who, uint256 amt) internal {
-        uint256 prevDate = stakeDate[who];
-        uint256 balance = balanceOf(who);
+    function _updateStakeDate(address account, uint256 amt) internal {
+        uint256 prevDate = stakeDate[account];
+        uint256 balance = balanceOf(account);
 
         // stakeDate + (now - stakeDate) * (amt / (balance + amt))
         // NOTE: prevDate = 0 implies balance = 0, and equation reduces to now
@@ -191,12 +193,12 @@ contract StakeLocker is StakeLockerFDT, Pausable {
             ? prevDate.add(block.timestamp.sub(prevDate).mul(amt).div(balance + amt))
             : prevDate;
 
-        stakeDate[who] = newDate;
-        emit StakeDateUpdated(who, newDate);
+        stakeDate[account] = newDate;
+        emit StakeDateUpdated(account, newDate);
     }
 
     /**
-        @dev Activates the cooldown period to unstake. It can't be called if the user is not staking.
+        @dev Activates the cooldown period to unstake. It can't be called if the account is not staking.
         @dev It emits a `Cooldown` event.
     **/
     function intendToUnstake() external {
@@ -224,13 +226,13 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     function unstake(uint256 amt) external canUnstake(msg.sender) {
         _whenProtocolNotPaused();
 
-        require(balanceOf(msg.sender).sub(amt) >= totalCustodyAllowance[msg.sender], "SL:INSUF_UNSTAKEABLE_BAL");  // User can only unstake tokens that aren't custodied
+        require(balanceOf(msg.sender).sub(amt) >= totalCustodyAllowance[msg.sender], "SL:INSUF_UNSTAKEABLE_BAL");  // Account can only unstake tokens that aren't custodied
         require(isUnstakeAllowed(msg.sender),                                        "SL:OUTSIDE_COOLDOWN");
         require(stakeDate[msg.sender].add(lockupPeriod) <= block.timestamp,          "SL:FUNDS_LOCKED");
 
-        updateFundsReceived();   // Account for any funds transferred into contract since last call
+        updateFundsReceived();   // Account for any funds transferred into contract since last call.
         _burn(msg.sender, amt);  // Burn the corresponding FDT balance.
-        withdrawFunds();         // Transfer full entitled liquidityAsset interest
+        withdrawFunds();         // Transfer full entitled liquidityAsset interest.
 
         stakeAsset.safeTransfer(msg.sender, amt.sub(_recognizeLosses()));  // Unstake amt minus losses
 
@@ -257,9 +259,11 @@ contract StakeLocker is StakeLockerFDT, Pausable {
 
     /**
         @dev   Increase the custody allowance for a given `custodian` corresponding to `msg.sender`.
-        @param custodian Address which will act as custodian of a given `amount` for a tokenHolder.
+        @dev   It emits a `CustodyAllowanceChanged` event.
+        @dev   It emits a `TotalCustodyAllowanceUpdated` event.
+        @param custodian Address which will act as custodian of a given `amount` for an account.
         @param amount    Number of FDTs custodied by the custodian.
-     */
+    */
     function increaseCustodyAllowance(address custodian, uint256 amount) external {
         uint256 oldAllowance      = custodyAllowance[msg.sender][custodian];
         uint256 newAllowance      = oldAllowance.add(amount);
@@ -267,20 +271,24 @@ contract StakeLocker is StakeLockerFDT, Pausable {
 
         require(custodian != address(0),                    "SL:INVALID_CUSTODIAN");
         require(amount    != uint256(0),                    "SL:INVALID_AMT");
-        require(newTotalAllowance <= balanceOf(msg.sender), "SL:INSUFFICIENT_BALANCE");
+        require(newTotalAllowance <= balanceOf(msg.sender), "SL:INSUF_BALANCE");
 
         custodyAllowance[msg.sender][custodian] = newAllowance;
         totalCustodyAllowance[msg.sender]       = newTotalAllowance;
         emit CustodyAllowanceChanged(msg.sender, custodian, oldAllowance, newAllowance);
+        emit TotalCustodyAllowanceUpdated(msg.sender, newTotalAllowance);
     }
 
     /**
         @dev   `from` and `to` should always be equal in this implementation.
         @dev   This means that the custodian can only decrease their own allowance and unlock funds for the original owner.
+        @dev   It emits a `CustodyTransfer` event.
+        @dev   It emits a `CustodyAllowanceChanged` event.
+        @dev   It emits a `TotalCustodyAllowanceUpdated` event.
         @param from   Address which holds the StakeLocker FDTs.
         @param to     Address which will be the new owner of the `amount` of FDTs.
         @param amount Number of FDTs transferred.
-     */
+    */
     function transferByCustodian(address from, address to, uint256 amount) external {
         uint256 oldAllowance = custodyAllowance[from][msg.sender];
         uint256 newAllowance = oldAllowance.sub(amount);
@@ -289,9 +297,11 @@ contract StakeLocker is StakeLockerFDT, Pausable {
         require(amount != uint256(0),   "SL:INVALID_AMT");
 
         custodyAllowance[from][msg.sender] = newAllowance;
-        totalCustodyAllowance[from]        = totalCustodyAllowance[from].sub(amount);
+        uint256 newTotalAllowance          = totalCustodyAllowance[from].sub(amount);
+        totalCustodyAllowance[from]        = newTotalAllowance;
         emit CustodyTransfer(msg.sender, from, to, amount);
         emit CustodyAllowanceChanged(from, msg.sender, oldAllowance, newAllowance);
+        emit TotalCustodyAllowanceUpdated(msg.sender, newTotalAllowance);
     }
 
     /**
@@ -302,11 +312,11 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     */
     function _transfer(address from, address to, uint256 wad) internal override canUnstake(from) {
         _whenProtocolNotPaused();
-        require(stakeDate[from].add(lockupPeriod) <= block.timestamp,    "SL:FUNDS_LOCKED");                  // Restrict transfer during lockup period
-        require(balanceOf(from).sub(wad) >= totalCustodyAllowance[from], "SL:INSUFFICENT_TRANSFERABLE_BAL");  // User can only transfer tokens that aren't custodied
-        require(isReceiveAllowed(unstakeCooldown[to]),                   "SL:RECIPIENT_NOT_ALLOWED");         // Recipient must not be currently unstaking
-        require(recognizableLossesOf(from) == uint256(0),                "SL:RECOG_LOSSES");                  // If a staker has unrecognized losses, they must recognize losses through unstake
-        _updateStakeDate(to, wad);                                                                            // Update stake date of recipient
+        require(stakeDate[from].add(lockupPeriod) <= block.timestamp,    "SL:FUNDS_LOCKED");            // Restrict transfer during lockup period
+        require(balanceOf(from).sub(wad) >= totalCustodyAllowance[from], "SL:INSUF_TRANSFERABLE_BAL");  // Account can only transfer tokens that aren't custodied
+        require(isReceiveAllowed(unstakeCooldown[to]),                   "SL:RECIPIENT_NOT_ALLOWED");   // Recipient must not be currently unstaking
+        require(recognizableLossesOf(from) == uint256(0),                "SL:RECOG_LOSSES");            // If a staker has unrecognized losses, they must recognize losses through unstake
+        _updateStakeDate(to, wad);                                                                      // Update stake date of recipient
         super._transfer(from, to, wad);
     }
 
@@ -368,9 +378,9 @@ contract StakeLocker is StakeLockerFDT, Pausable {
     /**
         @dev Checks that `msg.sender` is allowed to stake.
     */
-    function _isAllowed(address user) internal view {
+    function _isAllowed(address account) internal view {
         require(
-            openToPublic || allowed[user] || user == IPool(pool).poolDelegate(),
+            openToPublic || allowed[account] || account == IPool(pool).poolDelegate(),
             "SL:NOT_ALLOWED"
         );
     }

--- a/contracts/interfaces/IERC2258.sol
+++ b/contracts/interfaces/IERC2258.sol
@@ -3,17 +3,17 @@ pragma solidity 0.6.11;
 
 interface IERC2258 {
 
-    // Increase the custody limit of a custodian either directly or via signed authorisation
+    // Increase the custody limit of a custodian either directly or via signed authorization
     function increaseCustodyAllowance(address custodian, uint256 amount) external;
 
     // Query individual custody limit and total custody limit across all custodians
-    function custodyAllowance(address tokenHolder, address custodian) external view returns (uint256);
-    function totalCustodyAllowance(address tokenHolder) external view returns (uint256);
+    function custodyAllowance(address account, address custodian) external view returns (uint256);
+    function totalCustodyAllowance(address account) external view returns (uint256);
 
     // Allows a custodian to exercise their right to transfer custodied tokens
-    function transferByCustodian(address tokenHolder, address receiver, uint256 amount) external;
+    function transferByCustodian(address account, address receiver, uint256 amount) external;
 
     // Custody Events
     event CustodyTransfer(address custodian, address from, address to, uint256 amount);
-    event CustodyAllowanceChanged(address tokenHolder, address custodian, uint256 oldAllowance, uint256 newAllowance);
+    event CustodyAllowanceChanged(address account, address custodian, uint256 oldAllowance, uint256 newAllowance);
 }

--- a/contracts/interfaces/ILoan.sol
+++ b/contracts/interfaces/ILoan.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity 0.6.11;
 
-import "../token/interfaces/IFDT.sol";
+import "../token/interfaces/ILoanFDT.sol";
 
-interface ILoan is IFDT {
+interface ILoan is ILoanFDT {
     
     // State Variables
     function liquidityAsset() external view returns (address);

--- a/contracts/interfaces/IMplRewards.sol
+++ b/contracts/interfaces/IMplRewards.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.6.11;
 
 interface IMplRewards {
+
     // Views
     function rewardsToken() external view returns (address);
 

--- a/contracts/library/LoanLib.sol
+++ b/contracts/library/LoanLib.sol
@@ -35,7 +35,7 @@ library LoanLib {
         @param  liquidityAsset  Contract address of the liquidity asset.
         @param  collateralAsset Contract address of the collateral asset.
         @param  specs           Contains specifications for this loan.
-     */
+    */
     function loanSanityChecks(IMapleGlobals globals, address liquidityAsset, address collateralAsset, uint256[5] calldata specs) external view {
         require(globals.isValidLiquidityAsset(liquidityAsset),   "L:INVALID_LIQ_ASSET");
         require(globals.isValidCollateralAsset(collateralAsset), "L:INVALID_COL_ASSET");

--- a/contracts/oracles/ChainlinkOracle.sol
+++ b/contracts/oracles/ChainlinkOracle.sol
@@ -22,10 +22,10 @@ contract ChainlinkOracle is Ownable {
 
     /**
         @dev   Creates a new Chainlink based oracle.
-        @param _aggregator   Address of Chainlink aggregator
-        @param _assetAddress Address of currency (0x0 for ETH)
-        @param _owner        Address of the owner of the contract
-      */
+        @param _aggregator   Address of Chainlink aggregator.
+        @param _assetAddress Address of currency (0x0 for ETH).
+        @param _owner        Address of the owner of the contract.
+    */
     constructor(address _aggregator, address _assetAddress, address _owner) public {
         require(_aggregator != address(0), "CO:ZERO_AGGREGATOR_ADDR");
         priceFeed       = IChainlinkAggregatorV3(_aggregator);
@@ -89,7 +89,7 @@ contract ChainlinkOracle is Ownable {
     /**
         @dev   Set manual override, allowing for manual price setting. Only the contract Owner can call this function.
         @dev   It emits a `SetManualOverride` event.
-        @param _override Whether to use the manual override price or not
+        @param _override Whether to use the manual override price or not.
     */
     function setManualOverride(bool _override) public onlyOwner {
         manualOverride = _override;

--- a/contracts/test/Loan.t.sol
+++ b/contracts/test/Loan.t.sol
@@ -258,7 +258,7 @@ contract LoanTest is TestUtil {
         assertEq(loan.principalOwed(),                                     drawdownAmount);  // Principal owed
         assertEq(uint256(loan.loanState()),                                             1);  // Loan state: Active
 
-        withinDiff(usdc.balanceOf(address(bob)), drawdownAmount - (investorFee + treasuryFee), 1); // Borrower liqudityAsset balance
+        withinDiff(usdc.balanceOf(address(bob)), drawdownAmount - (investorFee + treasuryFee), 1); // Borrower liquidityAsset balance
 
         assertEq(loan.nextPaymentDue(), block.timestamp + loan.paymentIntervalSeconds());  // Next payment due timestamp calculated from time of drawdown
 
@@ -777,9 +777,9 @@ contract LoanTest is TestUtil {
         mint("USDC", address(bob),       total);
         bob.approve(USDC, address(loan), total);
 
-        // Below is the way of catering two senarios
+        // Below is the way of catering two scenarios
         // 1. When there is no late payment so interest paid will be a multiple of `numPayments`.
-        // 2. If there is a late payment then needs to handle the situation where interst paid is `interest (without late fee) + interest (late fee) * numPayments`.
+        // 2. If there is a late payment then needs to handle the situation where interest paid is `interest (without late fee) + interest (late fee) * numPayments`.
         numPayments = oldInterest == uint256(0) ? numPayments - paymentCount : numPayments - paymentCount - 1;
         // Make payment.
         assertTrue(bob.try_makePayment(address(loan)));

--- a/contracts/test/LoanFactory.t.sol
+++ b/contracts/test/LoanFactory.t.sol
@@ -141,7 +141,7 @@ contract LoanFactoryTest is TestUtil {
         // Verify the loan gets created successfully.
         assertTrue(bob.try_createLoan(address(loanFactory), USDC, WETH, address(flFactory), address(clFactory), specs, calcs));
         assertEq(loanFactory.loansCreated(), 1, "Incorrect loan instantiation");  // Should be incremented by 1.
-        ILoan loan = ILoan(loanFactory.loans(0));                                 // Intital value of loansCreated.
+        ILoan loan = ILoan(loanFactory.loans(0));                                 // Initial value of loansCreated.
         assertTrue(loanFactory.isLoan(address(loan)));                            // Should be considered as a loan.
 
         // Verify the storage of loan contract

--- a/contracts/test/MapleTreasury.t.sol
+++ b/contracts/test/MapleTreasury.t.sol
@@ -67,7 +67,7 @@ contract MapleTreasuryTest is TestUtil {
         assertTrue(     gov.try_distributeToHolders());  // Governor can distribute
 
         assertEq(IERC20(USDC).balanceOf(address(treasury)),         0);  // Withdraws all funds
-        assertEq(IERC20(USDC).balanceOf(address(mpl)),      100 * USD);  // Withdrawn to MPL address, where users can claim funds
+        assertEq(IERC20(USDC).balanceOf(address(mpl)),      100 * USD);  // Withdrawn to MPL address, where accounts can claim funds
 
         assertEq(IERC20(USDC).balanceOf(address(hal)), 0);  // Token holder hasn't claimed
         assertEq(IERC20(USDC).balanceOf(address(hue)), 0);  // Token holder hasn't claimed

--- a/contracts/test/MplRewards.t.sol
+++ b/contracts/test/MplRewards.t.sol
@@ -208,7 +208,7 @@ contract MplRewardsTest is TestUtil {
     }
 
     function assertRewardsAccounting(
-        address user,
+        address account,
         uint256 totalSupply,
         uint256 rewardPerTokenStored,
         uint256 userRewardPerTokenPaid,
@@ -218,12 +218,12 @@ contract MplRewardsTest is TestUtil {
     )
         public
     {
-        assertEq(mplRewards.totalSupply(),                totalSupply);
-        assertEq(mplRewards.rewardPerTokenStored(),       rewardPerTokenStored);
-        assertEq(mplRewards.userRewardPerTokenPaid(user), userRewardPerTokenPaid);
-        assertEq(mplRewards.earned(user),                 earned);
-        assertEq(mplRewards.rewards(user),                rewards);
-        assertEq(mpl.balanceOf(user),                     rewardTokenBal);
+        assertEq(mplRewards.totalSupply(),                   totalSupply);
+        assertEq(mplRewards.rewardPerTokenStored(),          rewardPerTokenStored);
+        assertEq(mplRewards.userRewardPerTokenPaid(account), userRewardPerTokenPaid);
+        assertEq(mplRewards.earned(account),                 earned);
+        assertEq(mplRewards.rewards(account),                rewards);
+        assertEq(mpl.balanceOf(account),                     rewardTokenBal);
     }
 
     /**********************************/
@@ -249,7 +249,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = 0 post-stake ***/
         assertRewardsAccounting({
-            user:                   address(fay),  // User for accounting
+            account:                address(fay),  // Account for accounting
             totalSupply:            10 * WAD,      // Ali's stake
             rewardPerTokenStored:   0,             // Starting state
             userRewardPerTokenPaid: 0,             // Starting state
@@ -262,7 +262,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (0 days) post-claim ***/
         assertRewardsAccounting({
-            user:                   address(fay),  // User for accounting
+            account:                address(fay),  // Account for accounting
             totalSupply:            10 * WAD,      // Ali's stake
             rewardPerTokenStored:   0,             // Starting state (getReward has no effect at time = 0)
             userRewardPerTokenPaid: 0,             // Starting state (getReward has no effect at time = 0)
@@ -278,7 +278,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (1 days) pre-claim ***/
         assertRewardsAccounting({
-            user:                   address(fay),                 // User for accounting
+            account:                address(fay),                 // Account for accounting
             totalSupply:            10 * WAD,                     // Ali's stake
             rewardPerTokenStored:   0,                            // Not updated yet
             userRewardPerTokenPaid: 0,                            // Not updated yet
@@ -291,20 +291,20 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (1 days) post-claim ***/
         assertRewardsAccounting({
-            user:                   address(fay),                // User for accounting
+            account:                address(fay),                // Account for accounting
             totalSupply:            10 * WAD,                    // Ali's stake
             rewardPerTokenStored:   dTime1_rpt,                  // Updated on updateReward
             userRewardPerTokenPaid: dTime1_rpt,                  // Updated on updateReward for 100% ownership in pool after 1hr
             earned:                 0,                           // Time-based calculation and userRewardPerTokenPaid cancel out
             rewards:                0,                           // Updated on updateReward to earned(), then set to zero on getReward
-            rewardTokenBal:         dTime1_rpt * 10 * WAD / WAD  // Updated on getReward, user has claimed rewards (equal to original earned() amt at this timestamp))
+            rewardTokenBal:         dTime1_rpt * 10 * WAD / WAD  // Updated on getReward, account has claimed rewards (equal to original earned() amt at this timestamp))
         });
 
         fez.stake(10 * WAD); // Bob stakes 10 FDTs, giving him 50% stake in the pool rewards going forward
 
         /*** Bob time = (1 days) post-stake ***/
         assertRewardsAccounting({
-            user:                   address(fez),  // User for accounting
+            account:                address(fez),  // Account for accounting
             totalSupply:            20 * WAD,      // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt,    // Doesn't change since no time has passed
             userRewardPerTokenPaid: dTime1_rpt,    // Used so Bob can't claim past rewards
@@ -320,7 +320,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (2 days) pre-claim ***/
         assertRewardsAccounting({
-            user:                   address(fay),                 // User for accounting
+            account:                address(fay),                 // Account for accounting
             totalSupply:            20 * WAD,                     // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt,                   // Not updated yet
             userRewardPerTokenPaid: dTime1_rpt,                   // Used so Ali can't do multiple claims
@@ -331,7 +331,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Bob time = (2 days) pre-claim ***/
         assertRewardsAccounting({
-            user:                   address(fez),                 // User for accounting
+            account:                address(fez),                 // Account for accounting
             totalSupply:            20 * WAD,                     // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt,                   // Not updated yet
             userRewardPerTokenPaid: dTime1_rpt,                   // Used so Bob can't do claims on past rewards
@@ -344,7 +344,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Bob time = (2 days) post-stake ***/
         assertRewardsAccounting({
-            user:                   address(fez),                 // User for accounting
+            account:                address(fez),                 // Account for accounting
             totalSupply:            40 * WAD,                     // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt,      // Updated on updateReward to snapshot rewardPerToken up to that point
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt,      // Used so Bob can't do claims on past rewards
@@ -359,7 +359,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (2 days + 1 hours) pre-claim ***/
         assertRewardsAccounting({
-            user:                   address(fay),                                // User for accounting
+            account:                address(fay),                                // Account for accounting
             totalSupply:            40 * WAD,                                    // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt,                     // Not updated yet
             userRewardPerTokenPaid: dTime1_rpt,                                  // Used so Ali can't do multiple claims
@@ -370,7 +370,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Bob time = (2 days + 1 hours) pre-claim ***/
         assertRewardsAccounting({
-            user:                   address(fez),                                           // User for accounting
+            account:                address(fez),                                           // Account for accounting
             totalSupply:            40 * WAD,                                               // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt,                                // Not updated yet
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt,                                // Used so Bob can't do claims on past rewards
@@ -383,20 +383,20 @@ contract MplRewardsTest is TestUtil {
 
         /*** Bob time = (2 days + 1 hours) post-claim ***/
         assertRewardsAccounting({
-            user:                   address(fez),                                          // User for accounting
+            account:                address(fez),                                          // Account for accounting
             totalSupply:            40 * WAD,                                              // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt + dTime3_rpt,                  // Updated on updateReward
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt + dTime3_rpt,                  // Used so Bob can't do multiple claims
             earned:                 0,                                                     // Time-based calculation and userRewardPerTokenPaid cancel out
             rewards:                0,                                                     // Updated on updateReward to earned(), then set to zero on getReward
-            rewardTokenBal:         (dTime2_rpt * 10 * WAD + dTime3_rpt * 30 * WAD) / WAD  // Updated on getReward, user has claimed rewards (equal to original earned() amt at this timestamp))
+            rewardTokenBal:         (dTime2_rpt * 10 * WAD + dTime3_rpt * 30 * WAD) / WAD  // Updated on getReward, account has claimed rewards (equal to original earned() amt at this timestamp))
         });
 
         fez.getReward();  // Try double claim
 
         /*** Bob time = (2 days + 1 hours) post-claim (ASSERT NOTHING CHANGES) ***/
         assertRewardsAccounting({
-            user:                   address(fez),                                          // Doesn't change
+            account:                address(fez),                                          // Doesn't change
             totalSupply:            40 * WAD,                                              // Doesn't change
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt + dTime3_rpt,                  // Doesn't change
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt + dTime3_rpt,                  // Doesn't change
@@ -409,7 +409,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (2 days + 1 hours) pre-claim ***/
         assertRewardsAccounting({
-            user:                   address(fay),                                // User for accounting
+            account:                address(fay),                                // Account for accounting
             totalSupply:            35 * WAD,                                    // Ali + Bob stake, lower now that Ali withdrew
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt + dTime3_rpt,        // From Bob's update
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt + dTime3_rpt,        // Used so Ali can't claim past earnings
@@ -424,7 +424,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (3 days + 1 hours) pre-exit ***/
         assertRewardsAccounting({
-            user:                   address(fay),                                                         // User for accounting
+            account:                address(fay),                                                         // Account for accounting
             totalSupply:            35 * WAD,                                                             // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt + dTime3_rpt,                                 // Not updated yet
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt + dTime3_rpt,                                 // Used so Ali can't do multiple claims
@@ -435,7 +435,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Bob time = (2 days + 1 hours) pre-exit ***/
         assertRewardsAccounting({
-            user:                   address(fez),                                          // User for accounting
+            account:                address(fez),                                          // Account for accounting
             totalSupply:            35 * WAD,                                              // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt + dTime3_rpt,                  // Not updated yet
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt + dTime3_rpt,                  // Used so Bob can't do multiple claims
@@ -449,7 +449,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (3 days + 1 hours) post-exit ***/
         assertRewardsAccounting({
-            user:                   address(fay),                                                                     // User for accounting
+            account:                address(fay),                                                                     // Account for accounting
             totalSupply:            0,                                                                                // Ali + Bob withdrew all stake
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt + dTime3_rpt + dTime4_rpt,                                // Updated on updateReward
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt + dTime3_rpt + dTime4_rpt,                                // Used so Ali can't do multiple claims
@@ -460,7 +460,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Bob time = (2 days + 1 hours) post-exit ***/
         assertRewardsAccounting({
-            user:                   address(fez),                                                         // User for accounting
+            account:                address(fez),                                                         // Account for accounting
             totalSupply:            0,                                                                    // Ali + Bob withdrew all stake
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt + dTime3_rpt + dTime4_rpt,                    // Updated on updateReward
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt + dTime3_rpt + dTime4_rpt,                    // Used so Bob can't do multiple claims
@@ -505,7 +505,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (30 days) pre-claim ***/
         assertRewardsAccounting({
-            user:                   address(fay),                 // User for accounting
+            account:                address(fay),                 // Account for accounting
             totalSupply:            40 * WAD,                     // Ali + Bob stake
             rewardPerTokenStored:   0,                            // Not updated yet
             userRewardPerTokenPaid: 0,                            // Not updated yet
@@ -516,7 +516,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Bob time = (30 days) pre-claim ***/
         assertRewardsAccounting({
-            user:                   address(fez),                 // User for accounting
+            account:                address(fez),                 // Account for accounting
             totalSupply:            40 * WAD,                     // Ali + Bob stake
             rewardPerTokenStored:   0,                            // Not updated yet
             userRewardPerTokenPaid: 0,                            // Not updated yet
@@ -529,7 +529,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (30 days) post-claim ***/
         assertRewardsAccounting({
-            user:                   address(fay),                 // User for accounting
+            account:                address(fay),                 // Account for accounting
             totalSupply:            40 * WAD,                     // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt,                   // Updated on updateReward
             userRewardPerTokenPaid: dTime1_rpt,                   // Used so Ali can't do multiple claims
@@ -548,7 +548,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (31 days) pre-claim (ASSERT NOTHING CHANGES DUE TO EPOCH BEING OVER) ***/
         assertRewardsAccounting({
-            user:                   address(fay),                 // Doesn't change
+            account:                address(fay),                 // Doesn't change
             totalSupply:            40 * WAD,                     // Doesn't change
             rewardPerTokenStored:   dTime1_rpt,                   // Doesn't change
             userRewardPerTokenPaid: dTime1_rpt,                   // Doesn't change
@@ -561,7 +561,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (31 days) post-claim (ASSERT NOTHING CHANGES DUE TO EPOCH BEING OVER) ***/
         assertRewardsAccounting({
-            user:                   address(fay),                 // Doesn't change
+            account:                address(fay),                 // Doesn't change
             totalSupply:            40 * WAD,                     // Doesn't change
             rewardPerTokenStored:   dTime1_rpt,                   // Doesn't change
             userRewardPerTokenPaid: dTime1_rpt,                   // Doesn't change
@@ -574,7 +574,7 @@ contract MplRewardsTest is TestUtil {
         /*** EPOCH 2 STARTS ***/
         /**********************/
 
-        assertEq(mpl.balanceOf(address(mplRewards)), 25_000 * WAD - dTime1_rpt * 10 * WAD / WAD);  // Bob's claimabe MPL is still in the contract
+        assertEq(mpl.balanceOf(address(mplRewards)), 25_000 * WAD - dTime1_rpt * 10 * WAD / WAD);  // Bob's claimable MPL is still in the contract
 
         gov.setRewardsDuration(15 days);
 
@@ -592,7 +592,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (1 days into epoch 2) pre-exit ***/
         assertRewardsAccounting({
-            user:                   address(fay),                 // User for accounting
+            account:                address(fay),                 // Account for accounting
             totalSupply:            40 * WAD,                     // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt,                   // From last epoch
             userRewardPerTokenPaid: dTime1_rpt,                   // Used so Ali can't do multiple claims
@@ -603,7 +603,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Bob time = (1 days into epoch 2) pre-exit ***/
         assertRewardsAccounting({
-            user:                   address(fez),                                // User for accounting
+            account:                address(fez),                                // Account for accounting
             totalSupply:            40 * WAD,                                    // Ali + Bob stake
             rewardPerTokenStored:   dTime1_rpt,                                  // From last epoch
             userRewardPerTokenPaid: 0,                                           // Used so Ali can't do multiple claims
@@ -617,7 +617,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Ali time = (1 days into epoch 2) post-exit ***/
         assertRewardsAccounting({
-            user:                   address(fay),                                // User for accounting
+            account:                address(fay),                                // Account for accounting
             totalSupply:            0,                                           // Ali + Bob exited
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt,                     // Updated on updateReward
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt,                     // Used so Ali can't do multiple claims
@@ -628,7 +628,7 @@ contract MplRewardsTest is TestUtil {
 
         /*** Bob time = (1 days into epoch 2) post-exit ***/
         assertRewardsAccounting({
-            user:                   address(fez),                                // User for accounting
+            account:                address(fez),                                // Account for accounting
             totalSupply:            0,                                           // Ali + Bob exited
             rewardPerTokenStored:   dTime1_rpt + dTime2_rpt,                     // Updated on updateReward
             userRewardPerTokenPaid: dTime1_rpt + dTime2_rpt,                     // Used so Bob can't do multiple claims

--- a/contracts/test/PoolClaim.t.sol
+++ b/contracts/test/PoolClaim.t.sol
@@ -667,7 +667,7 @@ contract PoolClaimTest is TestUtil {
             // Eg. (interestClaimed / totalClaimed) * balance = Portion of total claim balance that is interest
             assertEq(calcAllotment(loanData[i] - debtLockerData[i], claim[0], sumNetNew), claim[i + 1]);
 
-            sumTransfer += balances[i + 6] - balances[i + 1]; // Sum up all transfers that occured from claim
+            sumTransfer += balances[i + 6] - balances[i + 1]; // Sum up all transfers that occurred from claim
         }
         
         assertEq(claim[0], sumTransfer); // Assert balance from withdrawFunds equals sum of transfers

--- a/contracts/test/PoolCustodial.t.sol
+++ b/contracts/test/PoolCustodial.t.sol
@@ -13,7 +13,7 @@ contract PoolCustodialTest is TestUtil {
     uint256 principalOut;        // Total outstanding principal of Pool
     uint256 liquidityLockerBal;  // Total liquidityAsset balance of LiquidityLocker
     uint256 fdtTotalSupply;      // PoolFDT total supply
-    uint256 interestSum;         // FDT accounting of interst earned
+    uint256 interestSum;         // FDT accounting of interest earned
     uint256 poolLosses;          // FDT accounting of recognizable losses
 
     TestObj withdrawableFundsOf_fay;  // FDT accounting of interest
@@ -207,7 +207,7 @@ contract PoolCustodialTest is TestUtil {
         // Testing failure modes with Fay
         assertTrue(!fay.try_increaseCustodyAllowance(address(pool), address(0),              depositAmt));  // P:INVALID_ADDRESS
         assertTrue(!fay.try_increaseCustodyAllowance(address(pool), address(custodian1),              0));  // P:INVALID_AMT
-        assertTrue(!fay.try_increaseCustodyAllowance(address(pool), address(custodian1), depositAmt + 1));  // P:INSUFFICIENT_BALANCE
+        assertTrue(!fay.try_increaseCustodyAllowance(address(pool), address(custodian1), depositAmt + 1));  // P:INSUF_BALANCE
         assertTrue( fay.try_increaseCustodyAllowance(address(pool), address(custodian1),     depositAmt));  // Fay can custody entire balance
 
         // Testing state transition and transfers with Fez
@@ -285,10 +285,10 @@ contract PoolCustodialTest is TestUtil {
 
         assertTrue(!custodian.try_transferByCustodian(address(pool), address(fay), address(fox),     custodyAmt));  // P:INVALID_RECEIVER
         assertTrue(!custodian.try_transferByCustodian(address(pool), address(fay), address(fay),              0));  // P:INVALID_AMT
-        assertTrue(!custodian.try_transferByCustodian(address(pool), address(fay), address(fay), custodyAmt + 1));  // P:INSUFFICIENT_ALLOWANCE
+        assertTrue(!custodian.try_transferByCustodian(address(pool), address(fay), address(fay), custodyAmt + 1));  // P:INSUF_ALLOWANCE
         assertTrue( custodian.try_transferByCustodian(address(pool), address(fay), address(fay),     custodyAmt));  // Able to transfer custody amount back
 
-        assertEq(pool.custodyAllowance(address(fay), address(custodian)), 0);  // Custodian alloance has been reduced
+        assertEq(pool.custodyAllowance(address(fay), address(custodian)), 0);  // Custodian allowance has been reduced
         assertEq(pool.totalCustodyAllowance(address(fay)),                0);  // Total custody allowance has been reduced, giving Fay access to funds again
     }
 }

--- a/contracts/test/PoolDelegate.t.sol
+++ b/contracts/test/PoolDelegate.t.sol
@@ -52,7 +52,7 @@ contract PoolTest is TestUtil {
             assertEq(minCover, globals.swapOutRequired() * USD);                     // Equal to globally specified value
             assertEq(curCover, 0);                                                   // Nothing staked
             assertTrue(!covered);                                                    // Not covered
-            assertEq(minStake, calc_minStake);                                       // Mininum stake equals calculated minimum stake     
+            assertEq(minStake, calc_minStake);                                       // Minimum stake equals calculated minimum stake     
             assertEq(curStake, calc_stakerBal);                                      // Current stake equals calculated stake
             assertEq(curStake, IERC20(pool.stakeLocker()).balanceOf(address(pat)));  // Current stake equals balance of stakeLocker FDTs
         }
@@ -205,7 +205,7 @@ contract PoolTest is TestUtil {
         assertEq(usdc.balanceOf(liqLocker),                    depositAmt - fundAmt);  // Balance of Liquidity Locker
         assertEq(usdc.balanceOf(address(fundingLocker)),                    fundAmt);  // Balance of Funding Locker
         assertEq(IERC20(loan).balanceOf(address(debtLocker)),        toWad(fundAmt));  // LoanFDT balance of DebtLocker
-        assertEq(pool.principalOut(),                                       fundAmt);  // Outstanding principal in liqiudity pool 1
+        assertEq(pool.principalOut(),                                       fundAmt);  // Outstanding principal in liquidity pool 1
 
         /****************************************/
         /*** Fund same loan with the same DL ***/
@@ -219,7 +219,7 @@ contract PoolTest is TestUtil {
         assertEq(usdc.balanceOf(liqLocker),                    depositAmt - fundAmt - newFundAmt);  // Balance of Liquidity Locker
         assertEq(usdc.balanceOf(address(fundingLocker)),                    fundAmt + newFundAmt);  // Balance of Funding Locker
         assertEq(IERC20(loan).balanceOf(address(debtLocker)),        toWad(fundAmt + newFundAmt));  // LoanFDT balance of DebtLocker
-        assertEq(pool.principalOut(),                                       fundAmt + newFundAmt);  // Outstanding principal in liqiudity pool 1
+        assertEq(pool.principalOut(),                                       fundAmt + newFundAmt);  // Outstanding principal in liquidity pool 1
 
         /*******************************************/
         /*** Fund same loan with a different DL ***/
@@ -239,7 +239,7 @@ contract PoolTest is TestUtil {
         assertEq(usdc.balanceOf(liqLocker),                    depositAmt - fundAmt - newFundAmt - newFundAmt2);  // Balance of Liquidity Locker
         assertEq(usdc.balanceOf(address(fundingLocker)),                    fundAmt + newFundAmt + newFundAmt2);  // Balance of Funding Locker
         assertEq(IERC20(loan).balanceOf(address(debtLocker2)),                              toWad(newFundAmt2));  // LoanFDT balance of DebtLocker 2
-        assertEq(pool.principalOut(),                                       fundAmt + newFundAmt + newFundAmt2);  // Outstanding principal in liqiudity pool 1
+        assertEq(pool.principalOut(),                                       fundAmt + newFundAmt + newFundAmt2);  // Outstanding principal in liquidity pool 1
     }
 
      function test_deactivate() public {

--- a/contracts/test/PoolLiquidityProvider.t.sol
+++ b/contracts/test/PoolLiquidityProvider.t.sol
@@ -239,12 +239,12 @@ contract PoolTest is TestUtil {
         assertTrue(liz.try_intendToWithdraw(address(pool)), "Failed to intend to withdraw");
         assertEq( pool.withdrawCooldown(address(liz)), start);
 
-        // LP (Leo) fails to transfer to LP (liz) who is currently withdrawing
+        // LP (Leo) fails to transfer to LP (liz) that is currently withdrawing
         assertTrue(!leo.try_transfer(address(pool), address(liz), toWad(depositAmt)));
         hevm.warp(start + globals.lpCooldownPeriod() + globals.lpWithdrawWindow());  // Very end of LP withdrawal window
         assertTrue(!leo.try_transfer(address(pool), address(liz), toWad(depositAmt)));
 
-        // LP (leo) successfully transfers to LP (liz) who is outside withdraw window
+        // LP (leo) successfully transfers to LP (liz) that is outside withdraw window
         hevm.warp(start + globals.lpCooldownPeriod() + globals.lpWithdrawWindow() + 1);  // Second after LP withdrawal window ends
         assertTrue( leo.try_transfer(address(pool), address(liz), toWad(depositAmt)));
         assertTrue(!liz.try_withdraw(address(pool), toWad(depositAmt)));
@@ -272,7 +272,7 @@ contract PoolTest is TestUtil {
         uint256 amt   = depositAmt / 3; // 1/3 of deposit so withdraw can happen thrice
         uint256 start = block.timestamp;
 
-        assertTrue(!leo.try_withdraw(address(pool), amt),     "Should fail to withdraw 500 USD because user has to intendToWithdraw");
+        assertTrue(!leo.try_withdraw(address(pool), amt),     "Should fail to withdraw 500 USD because account has to intendToWithdraw");
         assertTrue(!lex.try_intendToWithdraw(address(pool)),  "Should fail to intend to withdraw because lex has zero pool FDTs");
         assertTrue( leo.try_intendToWithdraw(address(pool)),  "Should fail to intend to withdraw");
         assertEq(  pool.withdrawCooldown(address(leo)), start);
@@ -347,7 +347,7 @@ contract PoolTest is TestUtil {
         doFullLoanPayment(loan3, bud); 
         pat.claim(address(pool), address(loan3), address(dlFactory));
 
-        uint256 interest = pool.withdrawableFundsOf(address(lee));  // Get kims withdrawable funds
+        uint256 interest = pool.withdrawableFundsOf(address(lee));  // Get kim's withdrawable funds
 
         assertTrue(lee.try_intendToWithdraw(address(pool)));
         // Warp to exact time that lee can withdraw with weighted deposit date
@@ -394,7 +394,7 @@ contract PoolTest is TestUtil {
         assertTrue( lee.try_intendToWithdraw(address(pool)));
         assertTrue(!lee.try_withdraw(address(pool), newDepositAmt + depositAmt), "Withdraw failure didn't trigger");                // Not able to withdraw the funds as deposit date was updated
 
-        uint256 interest = pool.withdrawableFundsOf(address(lee));  // Get kims withdrawable funds
+        uint256 interest = pool.withdrawableFundsOf(address(lee));  // Get kim's withdrawable funds
 
         // Warp to exact time that lee can withdraw with weighted deposit date
         assertTrue(!lee.try_withdraw(address(pool), newDepositAmt + depositAmt), "Withdraw failure didn't trigger");

--- a/contracts/test/StakeLockerCustodial.t.sol
+++ b/contracts/test/StakeLockerCustodial.t.sol
@@ -42,7 +42,7 @@ contract StakeLockerCustodialTest is TestUtil {
         // Testing failure modes with Sam
         assertTrue(!sam.try_increaseCustodyAllowance(address(stakeLocker), address(0),              stakeAmt));  // P:INVALID_ADDRESS
         assertTrue(!sam.try_increaseCustodyAllowance(address(stakeLocker), address(custodian1),            0));  // P:INVALID_AMT
-        assertTrue(!sam.try_increaseCustodyAllowance(address(stakeLocker), address(custodian1), stakeAmt + 1));  // P:INSUFFICIENT_BALANCE
+        assertTrue(!sam.try_increaseCustodyAllowance(address(stakeLocker), address(custodian1), stakeAmt + 1));  // P:INSUF_BALANCE
         assertTrue( sam.try_increaseCustodyAllowance(address(stakeLocker), address(custodian1),     stakeAmt));  // Sam can custody entire balance
 
         // Testing state transition and transfers with Sid
@@ -98,7 +98,7 @@ contract StakeLockerCustodialTest is TestUtil {
 
         assertEq(stakeLocker.balanceOf(address(sam)), stakeAmt);
 
-        make_unstakable(sam, stakeLocker);
+        make_unstakeable(sam, stakeLocker);
 
         assertTrue(!sam.try_unstake(address(stakeLocker), unstakeableAmt + 1));
         assertTrue( sam.try_unstake(address(stakeLocker),     unstakeableAmt));
@@ -125,10 +125,10 @@ contract StakeLockerCustodialTest is TestUtil {
 
         assertTrue(!custodian.try_transferByCustodian(address(stakeLocker), address(sam), address(sid),     custodyAmt));  // P:INVALID_RECEIVER
         assertTrue(!custodian.try_transferByCustodian(address(stakeLocker), address(sam), address(sam),              0));  // P:INVALID_AMT
-        assertTrue(!custodian.try_transferByCustodian(address(stakeLocker), address(sam), address(sam), custodyAmt + 1));  // P:INSUFFICIENT_ALLOWANCE
+        assertTrue(!custodian.try_transferByCustodian(address(stakeLocker), address(sam), address(sam), custodyAmt + 1));  // P:INSUF_ALLOWANCE
         assertTrue( custodian.try_transferByCustodian(address(stakeLocker), address(sam), address(sam),     custodyAmt));  // Able to transfer custody amount back
 
-        assertEq(stakeLocker.custodyAllowance(address(sam), address(custodian)), 0);  // Custodian alloance has been reduced
+        assertEq(stakeLocker.custodyAllowance(address(sam), address(custodian)), 0);  // Custodian allowance has been reduced
         assertEq(stakeLocker.totalCustodyAllowance(address(sam)),                0);  // Total custody allowance has been reduced, giving Sam access to funds again
     }
 }

--- a/contracts/test/TestUtil.sol
+++ b/contracts/test/TestUtil.sol
@@ -549,18 +549,18 @@ contract TestUtil is DSTest {
     }
 
     // Manipulate mainnet ERC20 balance
-    function mint(bytes32 symbol, address who, uint256 amt) public {
+    function mint(bytes32 symbol, address account, uint256 amt) public {
         address addr = tokens[symbol].addr;
         uint256 slot  = tokens[symbol].slot;
-        uint256 bal = IERC20(addr).balanceOf(who);
+        uint256 bal = IERC20(addr).balanceOf(account);
 
         hevm.store(
             addr,
-            keccak256(abi.encode(who, slot)), // Mint tokens
+            keccak256(abi.encode(account, slot)), // Mint tokens
             bytes32(bal + amt)
         );
 
-        assertEq(IERC20(addr).balanceOf(who), bal + amt); // Assert new balance
+        assertEq(IERC20(addr).balanceOf(account), bal + amt); // Assert new balance
     }
 
     // Verify equality within accuracy decimals
@@ -615,7 +615,7 @@ contract TestUtil is DSTest {
         uint256 termDays            = paymentIntervalDays * numPayments;
 
         specs = [
-            constrictToRange(apr, 1, 10_000, true),                     // APR between 0.01% and 100% (non-zero for test behaviour)
+            constrictToRange(apr, 1, 10_000, true),                     // APR between 0.01% and 100% (non-zero for test behavior)
             termDays,                                                   // Fuzzed term days
             paymentIntervalDays,                                        // Payment interval days from array
             constrictToRange(requestAmount, 1 * USD, 1E10 * USD, true), // 1 USD - 10b USD loans (non-zero)
@@ -732,7 +732,7 @@ contract TestUtil is DSTest {
     /***********************/
     /*** Staking Helpers ***/
     /***********************/
-    function make_unstakable(Staker staker, StakeLocker stakeLocker) internal {
+    function make_unstakeable(Staker staker, StakeLocker stakeLocker) internal {
         uint256 currentTime = block.timestamp;
         assertTrue(staker.try_intendToUnstake(address(stakeLocker)));
         assertEq(stakeLocker.unstakeCooldown(address(staker)), currentTime, "Incorrect value set");

--- a/contracts/test/user/Borrower.sol
+++ b/contracts/test/user/Borrower.sol
@@ -36,8 +36,8 @@ contract Borrower {
         ILoan(loan).drawdown(_drawdownAmount);
     }
 
-    function approve(address token, address who, uint256 amt) external {
-        IERC20(token).approve(who, amt);
+    function approve(address token, address account, uint256 amt) external {
+        IERC20(token).approve(account, amt);
     }
 
     function createLoan(

--- a/contracts/test/user/Farmer.sol
+++ b/contracts/test/user/Farmer.sol
@@ -21,12 +21,12 @@ contract Farmer is LP {
     /*** DIRECT FUNCTIONS ***/
     /************************/
 
-    function approve(address who, uint256 amt) public {
-        poolFDT.approve(who, amt);
+    function approve(address account, uint256 amt) public {
+        poolFDT.approve(account, amt);
     }
 
-    function increaseCustodyAllowance(address pool, address who, uint256 amt) public {
-        IPool(pool).increaseCustodyAllowance(who, amt);
+    function increaseCustodyAllowance(address pool, address account, uint256 amt) public {
+        IPool(pool).increaseCustodyAllowance(account, amt);
     }
 
     function transfer(address asset, address to, uint256 amt) public {
@@ -63,8 +63,8 @@ contract Farmer is LP {
         (ok,) = address(mplRewards).call(abi.encodeWithSignature(sig, amt));
     }
 
-    function try_increaseCustodyAllowance(address pool, address who, uint256 amt) external returns (bool ok) {
+    function try_increaseCustodyAllowance(address pool, address account, uint256 amt) external returns (bool ok) {
         string memory sig = "increaseCustodyAllowance(address,uint256)";
-        (ok,) = pool.call(abi.encodeWithSignature(sig, who, amt));
+        (ok,) = pool.call(abi.encodeWithSignature(sig, account, amt));
     }
 }

--- a/contracts/test/user/Governor.sol
+++ b/contracts/test/user/Governor.sol
@@ -33,7 +33,7 @@ contract Governor {
         return mplRewards;
     }
 
-    // Used for "fake" governors pointing at a globals contract they didnt create
+    // Used for "fake" governors pointing at a globals contract they didn't create
     function setGovGlobals(MapleGlobals _globals) external {
         globals = _globals;
     }
@@ -42,18 +42,18 @@ contract Governor {
         mplRewardsFactory = _mplRewardsFactory;
     }
 
-    // Used for "fake" governors pointing at a staking rewards contract they dont own
+    // Used for "fake" governors pointing at a staking rewards contract they don't own
     function setGovMplRewards(MplRewards _mplRewards) external {
         mplRewards = _mplRewards;
     }
 
-    // Used for "fake" governors pointing at a treasury contract they didnt create
+    // Used for "fake" governors pointing at a treasury contract they didn't create
     function setGovTreasury(MapleTreasury _treasury) external {
         treasury = _treasury;
     }
 
-    function transfer(IERC20 token, address who, uint256 amt) external {
-        token.transfer(who, amt);
+    function transfer(IERC20 token, address account, uint256 amt) external {
+        token.transfer(account, amt);
     }
 
     /*** MapleGlobals Setters ***/

--- a/contracts/test/user/LP.sol
+++ b/contracts/test/user/LP.sol
@@ -12,8 +12,8 @@ contract LP {
     /*** DIRECT FUNCTIONS ***/
     /************************/
 
-    function approve(address token, address who, uint256 amt) external {
-        IERC20(token).approve(who, amt);
+    function approve(address token, address account, uint256 amt) external {
+        IERC20(token).approve(account, amt);
     }
 
     function withdraw(address pool, uint256 amt) external {
@@ -24,8 +24,8 @@ contract LP {
         IPool(pool).deposit(amt);
     }
 
-    function transferFDT(address pool, address who, uint256 amt) external {
-        IPool(pool).transfer(who, amt);
+    function transferFDT(address pool, address account, uint256 amt) external {
+        IPool(pool).transfer(account, amt);
     }
 
     function claim(address pool, address loan, address dlFactory) external { IPool(pool).claim(loan, dlFactory); }
@@ -66,8 +66,8 @@ contract LP {
         (ok,) = pool.call(abi.encodeWithSignature(sig));
     }
 
-    function try_transfer(address pool, address who, uint256 amt) external returns (bool ok) {
+    function try_transfer(address pool, address account, uint256 amt) external returns (bool ok) {
         string memory sig = "transfer(address,uint256)";
-        (ok,) = pool.call(abi.encodeWithSignature(sig, who, amt));
+        (ok,) = pool.call(abi.encodeWithSignature(sig, account, amt));
     }
 }

--- a/contracts/test/user/Lender.sol
+++ b/contracts/test/user/Lender.sol
@@ -12,16 +12,16 @@ contract Lender {
     /*** DIRECT FUNCTIONS ***/
     /************************/
 
-    function fundLoan(address loan, uint256 amt, address who) external {
-        ILoan(loan).fundLoan(who, amt);
+    function fundLoan(address loan, uint256 amt, address account) external {
+        ILoan(loan).fundLoan(account, amt);
     }
 
-    function approve(address token, address who, uint256 amt) external {
-        IERC20(token).approve(who, amt);
+    function approve(address token, address account, uint256 amt) external {
+        IERC20(token).approve(account, amt);
     }
 
-    function transfer(address token, address who, uint256 amt) external {
-        IERC20(token).transfer(who, amt);
+    function transfer(address token, address account, uint256 amt) external {
+        IERC20(token).transfer(account, amt);
     }
 
     function triggerDefault(address loan) public {

--- a/contracts/test/user/PoolDelegate.sol
+++ b/contracts/test/user/PoolDelegate.sol
@@ -38,8 +38,8 @@ contract PoolDelegate {
         );
     }
 
-    function approve(address token, address who, uint256 amt) external {
-        IERC20(token).approve(who, amt);
+    function approve(address token, address account, uint256 amt) external {
+        IERC20(token).approve(account, amt);
     }
 
     function stake(address stakeLocker, uint256 amt) external {
@@ -94,16 +94,16 @@ contract PoolDelegate {
         IPool(pool).setStakingFee(stakingFee);
     }
 
-    function setAllowList(address pool, address user, bool status) external {
-        IPool(pool).setAllowList(user, status);
+    function setAllowList(address pool, address account, bool status) external {
+        IPool(pool).setAllowList(account, status);
     }
 
     function openStakeLockerToPublic(address stakeLocker) external {
         IStakeLocker(stakeLocker).openStakeLockerToPublic();
     }
 
-    function setAllowlist(address stakeLocker, address user, bool status) external {
-        IStakeLocker(stakeLocker).setAllowlist(user, status);
+    function setAllowlist(address stakeLocker, address account, bool status) external {
+        IStakeLocker(stakeLocker).setAllowlist(account, status);
     }
 
     /*********************/
@@ -183,14 +183,14 @@ contract PoolDelegate {
         (ok,) = address(stakeLocker).call(abi.encodeWithSignature(sig));
     }
 
-    function try_setAllowList(address pool, address user, bool status) external returns (bool ok) {
+    function try_setAllowList(address pool, address account, bool status) external returns (bool ok) {
         string memory sig = "setAllowList(address,bool)";
-        (ok,) = address(pool).call(abi.encodeWithSignature(sig, user, status));
+        (ok,) = address(pool).call(abi.encodeWithSignature(sig, account, status));
     }
 
-    function try_setAllowlist(address stakeLocker, address user, bool status) external returns (bool ok) {
+    function try_setAllowlist(address stakeLocker, address account, bool status) external returns (bool ok) {
         string memory sig = "setAllowlist(address,bool)";
-        (ok,) = address(stakeLocker).call(abi.encodeWithSignature(sig, user, status));
+        (ok,) = address(stakeLocker).call(abi.encodeWithSignature(sig, account, status));
     }
 
     function try_setPoolAdmin(address pool, address newPoolAdmin, bool status) external returns (bool ok) {

--- a/contracts/test/user/Staker.sol
+++ b/contracts/test/user/Staker.sol
@@ -12,12 +12,12 @@ contract Staker {
     /*** DIRECT FUNCTIONS ***/
     /************************/
 
-    function approve(address token, address who, uint256 amt) external {
-        IERC20(token).approve(who, amt);
+    function approve(address token, address account, uint256 amt) external {
+        IERC20(token).approve(account, amt);
     }
 
-    function increaseCustodyAllowance(address stakeLocker, address who, uint256 amt) public {
-        IStakeLocker(stakeLocker).increaseCustodyAllowance(who, amt);
+    function increaseCustodyAllowance(address stakeLocker, address account, uint256 amt) public {
+        IStakeLocker(stakeLocker).increaseCustodyAllowance(account, amt);
     }
 
     function stake(address stakeLocker, uint256 amt) external {
@@ -74,8 +74,8 @@ contract Staker {
         (ok,) = stakeLocker.call(abi.encodeWithSignature(sig));
     }
 
-    function try_increaseCustodyAllowance(address stakeLocker, address who, uint256 amt) external returns (bool ok) {
+    function try_increaseCustodyAllowance(address stakeLocker, address account, uint256 amt) external returns (bool ok) {
         string memory sig = "increaseCustodyAllowance(address,uint256)";
-        (ok,) = stakeLocker.call(abi.encodeWithSignature(sig, who, amt));
+        (ok,) = stakeLocker.call(abi.encodeWithSignature(sig, account, amt));
     }
 }

--- a/contracts/token/BasicFDT.sol
+++ b/contracts/token/BasicFDT.sol
@@ -50,7 +50,7 @@ abstract contract BasicFDT is IBaseFDT, ERC20 {
     }
 
     /**
-        @dev    Prepares funds withdrawal
+        @dev    Prepares funds withdrawal.
         @dev    It emits a `FundsWithdrawn` event if the amount of withdrawn funds is greater than 0.
         @return withdrawableDividend The amount of dividend funds that can be withdrawn.
     */
@@ -98,7 +98,7 @@ abstract contract BasicFDT is IBaseFDT, ERC20 {
 
     /**
         @dev   Internal function that transfer tokens from one address to another. Update pointsCorrection to keep funds unchanged.
-        @dev   It emits a `PointsCorrectionUpdated` event for the sender and receiver.
+        @dev   It emits two `PointsCorrectionUpdated` events, one for the sender and one for the receiver.
         @param from  The address to transfer from.
         @param to    The address to transfer to.
         @param value The amount to be transferred.
@@ -162,14 +162,14 @@ abstract contract BasicFDT is IBaseFDT, ERC20 {
 
     /**
         @dev    Updates the current funds token balance and returns the difference of new and previous funds token balances.
-        @return A int256 representing the difference of the new and previous funds token balance
+        @return A int256 representing the difference of the new and previous funds token balance.
     */
     function _updateFundsTokenBalance() internal virtual returns (int256) {}
 
     /**
         @dev Register a payment of funds in tokens. May be called directly after a deposit is made.
         @dev Calls _updateFundsTokenBalance(), whereby the contract computes the delta of the new and the previous
-             funds token balance and increments the total received funds (cumulative) by delta by calling _registerFunds()
+             funds token balance and increments the total received funds (cumulative) by delta by calling _registerFunds().
     */
     function updateFundsReceived() public virtual {
         int256 newFunds = _updateFundsTokenBalance();

--- a/contracts/token/ExtendedFDT.sol
+++ b/contracts/token/ExtendedFDT.sol
@@ -20,7 +20,7 @@ abstract contract ExtendedFDT is BasicFDT {
 
     /**
         @dev   This event emits when new losses are distributed.
-        @param by                The address of the sender who distributed losses.
+        @param by                The address of the sender account distributed losses.
         @param lossesDistributed The amount of losses received for distribution.
     */
     event LossesDistributed(address indexed by, uint256 lossesDistributed);
@@ -110,7 +110,7 @@ abstract contract ExtendedFDT is BasicFDT {
 
     /**
         @dev   Internal function that transfer tokens from one address to another. Update pointsCorrection to keep funds unchanged.
-        @dev         It emits a `LossesCorrectionUpdated` event for the sender and receiver.
+        @dev         It emits two `LossesCorrectionUpdated` events, one for the sender and one for the receiver.
         @param from  The address to transfer from
         @param to    The address to transfer to
         @param value The amount to be transferred
@@ -153,7 +153,7 @@ abstract contract ExtendedFDT is BasicFDT {
     /**
         @dev   Internal function that burns an amount of the token of a given account. Update lossesCorrection to keep losses unchanged.
         @dev   It emits a `LossesCorrectionUpdated` event.
-        @param account The account whose tokens will be burnt.
+        @param account The account from which tokens will be burnt.
         @param value   The amount that will be burnt.
     */
     function _burn(address account, uint256 value) internal virtual override {
@@ -171,7 +171,7 @@ abstract contract ExtendedFDT is BasicFDT {
     /**
         @dev Register a loss. May be called directly after a shortfall after BPT burning occurs.
         @dev Calls _updateLossesTokenBalance(), whereby the contract computes the delta of the new and the previous
-             losses and increments the total losses (cumulative) by delta by calling _distributeLosses()
+             losses and increments the total losses (cumulative) by delta by calling _distributeLosses().
     */
     function updateLossesReceived() public virtual {
         int256 newLosses = _updateLossesBalance();
@@ -182,7 +182,7 @@ abstract contract ExtendedFDT is BasicFDT {
     }
 
     /**
-        @dev Recognizes all recognizable losses for a user using loss accounting.
+        @dev Recognizes all recognizable losses for an account using loss accounting.
     */
     function _recognizeLosses() internal virtual returns (uint256 losses) { }
 

--- a/contracts/token/LoanFDT.sol
+++ b/contracts/token/LoanFDT.sol
@@ -5,8 +5,8 @@ import "lib/openzeppelin-contracts/contracts/token/ERC20/SafeERC20.sol";
 
 import "./BasicFDT.sol";
 
-/// @title FDT inherits BasicFDT and uses the original ERC-2222 logic.
-abstract contract FDT is BasicFDT {
+/// @title LoanFDT inherits BasicFDT and uses the original ERC-2222 logic.
+abstract contract LoanFDT is BasicFDT {
     using SafeMath       for uint256;
     using SafeMathUint   for uint256;
     using SignedSafeMath for  int256;

--- a/contracts/token/PoolFDT.sol
+++ b/contracts/token/PoolFDT.sol
@@ -10,8 +10,8 @@ abstract contract PoolFDT is ExtendedFDT {
     using SignedSafeMath for  int256;
     using SafeMathInt    for  int256;
 
-    uint256 public interestSum;  // Sum of all withdrawable interest
-    uint256 public poolLosses;   // Sum of all unrecognized losses
+    uint256 public interestSum;  // Sum of all withdrawable interest.
+    uint256 public poolLosses;   // Sum of all unrecognized losses.
 
     uint256 public interestBalance;  // The amount of earned interest present and accounted for in this contract.
     uint256 public lossesBalance;    // The amount of losses present and accounted for in this contract.

--- a/contracts/token/StakeLockerFDT.sol
+++ b/contracts/token/StakeLockerFDT.sol
@@ -3,7 +3,7 @@ pragma solidity 0.6.11;
 
 import "./ExtendedFDT.sol";
 
-/// @title PoolFDT inherits ExtendedFDT and accounts for gains/losses for Stakers.
+/// @title StakeLockerFDT inherits ExtendedFDT and accounts for gains/losses for Stakers.
 abstract contract StakeLockerFDT is ExtendedFDT {
     using SafeMath       for uint256;
     using SafeMathUint   for uint256;

--- a/contracts/token/interfaces/IBaseFDT.sol
+++ b/contracts/token/interfaces/IBaseFDT.sol
@@ -4,8 +4,8 @@ pragma solidity 0.6.11;
 interface IBaseFDT {
     /**
         @dev Returns the total amount of funds a given address is able to withdraw currently.
-        @param owner Address of FDT holder
-        @return A uint256 representing the available funds for a given account
+        @param owner Address of FDT holder.
+        @return A uint256 representing the available funds for a given account.
     */
     function withdrawableFundsOf(address owner) external view returns (uint256);
 
@@ -16,16 +16,16 @@ interface IBaseFDT {
 
     /**
         @dev This event emits when new funds are distributed.
-        @param by the address of the sender who distributed funds
-        @param fundsDistributed the amount of funds received for distribution
+        @param by the address of the sender that distributed funds.
+        @param fundsDistributed the amount of funds received for distribution.
     */
     event FundsDistributed(address indexed by, uint256 fundsDistributed);
 
     /**
         @dev This event emits when distributed funds are withdrawn by a token holder.
-        @param by the address of the receiver of funds
-        @param fundsWithdrawn the amount of funds that were withdrawn
-        @param totalWithdrawn the total amount of funds that were withdrawn
+        @param by the address of the receiver of funds.
+        @param fundsWithdrawn the amount of funds that were withdrawn.
+        @param totalWithdrawn the total amount of funds that were withdrawn.
     */
     event FundsWithdrawn(address indexed by, uint256 fundsWithdrawn, uint256 totalWithdrawn);
 }

--- a/contracts/token/interfaces/ILoanFDT.sol
+++ b/contracts/token/interfaces/ILoanFDT.sol
@@ -3,7 +3,7 @@ pragma solidity 0.6.11;
 
 import "./IBasicFDT.sol";
 
-interface IFDT is IBasicFDT {
+interface ILoanFDT is IBasicFDT {
     function fundsToken() external view returns (address);
 
     function fundsTokenBalance() external view returns (uint256);

--- a/contracts/token/interfaces/IStakeLockerFDT.sol
+++ b/contracts/token/interfaces/IStakeLockerFDT.sol
@@ -2,9 +2,12 @@
 pragma solidity 0.6.11;
 
 import "./IExtendedFDT.sol";
-import "./IFDT.sol";
 
-interface IStakeLockerFDT is IExtendedFDT, IFDT {
+interface IStakeLockerFDT is IExtendedFDT {
+    function fundsToken() external view returns (address);
+
+    function fundsTokenBalance() external view returns (uint256);
+
     function bptLosses() external view returns (uint256);
 
     function lossesBalance() external view returns (uint256);


### PR DESCRIPTION
# Description

Post-C4 Re-review Changes and Custodian Allowance considerations

# Integrations Checklist

- [X] Have any function signatures changed? If yes, outline below.
- [X] Have any features changed or been added? If yes, outline below.
- [X] Have any events changed or been added? If yes, outline below.
- [X] Has all documentation been updated?

# Changelog

- Renamed incorrectly named `FDT` contract and `IFDT` interface to `LoanFDT` and `ILoanFDT` respectively.
- Emitted a missing `BalanceUpdated` event in `Loan.withdrawFunds`.
- Put reused `Pool` code into a new internal `_canWithdraw` function.
- Slight reduction in gas by skipping the need for a `_globals` function in `PoolLib`, as it was only used once.
- Slight reduction in gas by making `PoolLib.bdiv` internal.
- Fixed last few NatSpec indentations issues
- Fixed typos in test comments
- Fixed incorrect NatSpec title for `StakeLockerFDT`
- `PoolDelegateAllowed` event renamed to `PoolDelegateSet`
- `_checkPercentageRange` now accepts the upper bound as an argument
- `setInvestorFee` and `setTreasuryFee` reuse new `_checkFee`, which itself uses updated `_checkPercentageRange`
- Gas savings by using `msg.sender` instead of `pendingGovernor` when setting `governor`
- `TotalCustodyAllowanceUpdated` emissions in `Pool` and `StakeLocker`
- Added more NatSpec for event emissions

## Function Signature Changes

## Features 

## Events

